### PR TITLE
Guess the Started time when submitting worklogs

### DIFF
--- a/source/StopWatch/Jira/IJiraApiRequestFactory.cs
+++ b/source/StopWatch/Jira/IJiraApiRequestFactory.cs
@@ -24,7 +24,7 @@ namespace StopWatch
         IRestRequest CreateGetFavoriteFiltersRequest();
         IRestRequest CreateGetIssuesByJQLRequest(string jql);
         IRestRequest CreateGetIssueSummaryRequest(string key);
-        IRestRequest CreatePostWorklogRequest(string key, TimeSpan time, string comment);
+        IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment);
         IRestRequest CreatePostCommentRequest(string key, string comment);
         IRestRequest CreateAuthenticateRequest(string username, string password);
         IRestRequest CreateReAuthenticateRequest();

--- a/source/StopWatch/Jira/JiraApiRequestFactory.cs
+++ b/source/StopWatch/Jira/JiraApiRequestFactory.cs
@@ -61,13 +61,14 @@ namespace StopWatch
         }
 
 
-        public IRestRequest CreatePostWorklogRequest(string key, TimeSpan time, string comment)
+        public IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment)
         {
             var request = restRequestFactory.Create(String.Format("/rest/api/2/issue/{0}/worklog", key.Trim()), Method.POST);
             request.RequestFormat = DataFormat.Json;
             request.AddBody(new
                 {
                     timeSpent = JiraTimeHelpers.TimeSpanToJiraTime(time),
+                    started = JiraTimeHelpers.DateTimeToJiraDateTime(started),
                     comment = comment
                 }
             );

--- a/source/StopWatch/Jira/JiraClient.cs
+++ b/source/StopWatch/Jira/JiraClient.cs
@@ -112,7 +112,8 @@ namespace StopWatch
 
         public bool PostWorklog(string key, TimeSpan time, string comment)
         {
-            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, time, comment);
+            var started = DateTimeOffset.UtcNow.Subtract(time);
+            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment);
             try
             {
                 jiraApiRequester.DoAuthenticatedRequest<object>(request);

--- a/source/StopWatch/JiraTimeHelpers.cs
+++ b/source/StopWatch/JiraTimeHelpers.cs
@@ -21,6 +21,12 @@ namespace StopWatch
 {
     static public class JiraTimeHelpers
     {
+        public static string DateTimeToJiraDateTime(DateTimeOffset date)
+        {
+            string formatted = date.ToString("yyyy-MM-dd\\THH:mm:ss.fffzzzz");
+            return formatted.Substring(0, formatted.Length - 3) + formatted.Substring(formatted.Length - 2);
+        }
+
         public static string TimeSpanToJiraTime(TimeSpan ts)
         {
             if (ts.Days > 0)

--- a/source/StopWatchTest/JiraApiRequestFactoryTest.cs
+++ b/source/StopWatchTest/JiraApiRequestFactoryTest.cs
@@ -74,9 +74,10 @@
         public void CreatePostWorklogRequest_CreatesValidRequest()
         {
             string key = "FOO-42";
+            var started = new DateTimeOffset(2016, 07, 26, 1, 44, 15, TimeSpan.Zero);
             TimeSpan time = new TimeSpan(1, 2, 0);
             string comment = "Sorry for the inconvenience...";
-            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, time, comment);
+            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment);
 
             requestFactoryMock.Verify(m => m.Create(String.Format("/rest/api/2/issue/{0}/worklog", key), Method.POST));
 
@@ -85,6 +86,7 @@
             requestMock.Verify(m => m.AddBody(It.Is<object>(o =>
                 o.GetHashCode() == (new {
                     timeSpent = JiraTimeHelpers.TimeSpanToJiraTime(time),
+                    started = "2016-07-26T01:44:15.000+0000",
                     comment = comment
                 }).GetHashCode()
             )));
@@ -95,13 +97,13 @@
         public void CreatePostWorklogRequest_RemoveLeadingAndTrailingSpacesFromIssueKey()
         {
             string key = "   FOO-42   ";
+            var started = new DateTimeOffset(2016, 07, 26, 1, 44, 15, TimeSpan.Zero);
             TimeSpan time = new TimeSpan(1, 2, 0);
             string comment = "Sorry for the inconvenience...";
-            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, time, comment);
+            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment);
 
             requestFactoryMock.Verify(m => m.Create(String.Format("/rest/api/2/issue/{0}/worklog", key.Trim()), Method.POST));
         }
-
 
         [Test]
         public void CreatePostCommentRequest_CreatesValidRequest()

--- a/source/StopWatchTest/JiraTimeHelpersTest.cs
+++ b/source/StopWatchTest/JiraTimeHelpersTest.cs
@@ -9,6 +9,14 @@
     public class JiraTimeHelpersTest
     {
         [Test]
+        public void DateTimeToJiraDateTime_HandlesTimeZones()
+        {
+            Assert.That(JiraTimeHelpers.DateTimeToJiraDateTime(new DateTimeOffset(2015, 09, 20, 16, 40, 51, TimeSpan.Zero)), Is.EqualTo("2015-09-20T16:40:51.000+0000"));
+            Assert.That(JiraTimeHelpers.DateTimeToJiraDateTime(new DateTimeOffset(2015, 09, 20, 16, 40, 51, TimeSpan.FromHours(1))), Is.EqualTo("2015-09-20T16:40:51.000+0100"));
+            Assert.That(JiraTimeHelpers.DateTimeToJiraDateTime(new DateTimeOffset(2015, 09, 20, 16, 40, 51, TimeSpan.FromMinutes(9 * 60 + 30))), Is.EqualTo("2015-09-20T16:40:51.000+0930"));
+        }
+
+        [Test]
         public void TimeSpanToJira_FormatsDaysHoursMinutes()
         {
             Assert.That(JiraTimeHelpers.TimeSpanToJiraTime(new TimeSpan(12, 7, 0)), Is.EqualTo("12h 7m"));


### PR DESCRIPTION
Fixes #26.

The `started` time is guessed based on the current time and the timeSpent being submitted.
I also added a DateTimeToJiraDateTime helper to convert DateTimeOffset values into JIRA's
unorthodox date format.

I figured `started` should be a parameter rather than defaulting to DateTime.Now within the function because that would make `CreatePostWorklogRequest` difficult to test. If you think it should be done differently I'd be interested to know, I've never used Moq before.