### PR TITLE
Added option to have control over remaining estimate when adding worklog to Jira (fixes #35)

### DIFF
--- a/source/StopWatch/App.config
+++ b/source/StopWatch/App.config
@@ -69,6 +69,9 @@ limitations under the License.
             <setting name="PostWorklogComment" serializeAs="String">
                 <value>0</value>
             </setting>
+            <setting name="AllowManualEstimateAdjustments" serializeAs="String">
+                <value>True</value>
+            </setting>
         </StopWatch.Properties.Settings>
     </userSettings>
 </configuration>

--- a/source/StopWatch/IssueControl.cs
+++ b/source/StopWatch/IssueControl.cs
@@ -423,7 +423,7 @@ namespace StopWatch
 
         private void btnPostAndReset_Click(object sender, EventArgs e)
         {
-            using (var worklogForm = new WorklogForm(Comment, EstimateUpdateMethod, EstimateUpdateValue))
+            using (var worklogForm = new WorklogForm(settings.AllowManualEstimateAdjustments, Comment, EstimateUpdateMethod, EstimateUpdateValue))
             {
                 var formResult = worklogForm.ShowDialog(this);
                 if (formResult == DialogResult.OK)

--- a/source/StopWatch/IssueControl.cs
+++ b/source/StopWatch/IssueControl.cs
@@ -54,6 +54,8 @@ namespace StopWatch
 
 
         public string Comment { get; set; }
+        public EstimateUpdateMethods EstimateUpdateMethod { get; set; }
+        public string EstimateUpdateValue { get; set; }
         #endregion
 
 
@@ -71,6 +73,8 @@ namespace StopWatch
             InitializeComponent();
 
             Comment = null;
+            EstimateUpdateMethod = EstimateUpdateMethods.Auto;
+            EstimateUpdateValue = null;
 
             this.settings = settings;
 
@@ -289,6 +293,8 @@ namespace StopWatch
         private void Reset()
         {
             Comment = null;
+            EstimateUpdateMethod = EstimateUpdateMethods.Auto;
+            EstimateUpdateValue = null;
             this.WatchTimer.Reset();
             UpdateOutput();
 
@@ -417,20 +423,22 @@ namespace StopWatch
 
         private void btnPostAndReset_Click(object sender, EventArgs e)
         {
-            using (var worklogForm = new WorklogForm(Comment))
+            using (var worklogForm = new WorklogForm(Comment, EstimateUpdateMethod, EstimateUpdateValue))
             {
                 var formResult = worklogForm.ShowDialog(this);
                 if (formResult == DialogResult.OK)
                 {
-                    EstimateUpdateMethods estimateUpdateMethod = worklogForm.estimateUpdateMethod;
-                    String estimateUpdateValue = worklogForm.EstimateValue;
                     Comment = worklogForm.Comment.Trim();
+                    EstimateUpdateMethod = worklogForm.estimateUpdateMethod;
+                    EstimateUpdateValue = worklogForm.EstimateValue;
 
-                    PostAndReset(cbJira.Text, WatchTimer.TimeElapsed, Comment, estimateUpdateMethod, estimateUpdateValue);
+                    PostAndReset(cbJira.Text, WatchTimer.TimeElapsed, Comment, EstimateUpdateMethod, EstimateUpdateValue);
                 }
                 else if (formResult == DialogResult.Yes)
                 {
                     Comment = string.Format("{0}:{1}{2}", DateTime.Now.ToString("g"), Environment.NewLine, worklogForm.Comment.Trim());
+                    EstimateUpdateMethod = worklogForm.estimateUpdateMethod;
+                    EstimateUpdateValue = worklogForm.EstimateValue;
                     UpdateOutput();
                 }
             }

--- a/source/StopWatch/IssueControl.cs
+++ b/source/StopWatch/IssueControl.cs
@@ -422,9 +422,11 @@ namespace StopWatch
                 var formResult = worklogForm.ShowDialog(this);
                 if (formResult == DialogResult.OK)
                 {
+                    EstimateUpdateMethods estimateUpdateMethod = worklogForm.estimateUpdateMethod;
+                    String estimateUpdateValue = worklogForm.EstimateValue;
                     Comment = worklogForm.Comment.Trim();
 
-                    PostAndReset(cbJira.Text, WatchTimer.TimeElapsed, Comment);
+                    PostAndReset(cbJira.Text, WatchTimer.TimeElapsed, Comment, estimateUpdateMethod, estimateUpdateValue);
                 }
                 else if (formResult == DialogResult.Yes)
                 {
@@ -451,7 +453,7 @@ namespace StopWatch
 
 
         #region private methods
-        private void PostAndReset(string key, TimeSpan timeElapsed, string comment)
+        private void PostAndReset(string key, TimeSpan timeElapsed, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {
             Task.Factory.StartNew(
                 () =>
@@ -476,7 +478,7 @@ namespace StopWatch
 
                     // Now post the WorkLog with timeElapsed - and comment unless it was reset
                     if (postSuccesful)
-                        postSuccesful = jiraClient.PostWorklog(key, timeElapsed, comment);
+                        postSuccesful = jiraClient.PostWorklog(key, timeElapsed, comment, estimateUpdateMethod, estimateUpdateValue);
 
                     if (postSuccesful)
                     {

--- a/source/StopWatch/Jira/IJiraApiRequestFactory.cs
+++ b/source/StopWatch/Jira/IJiraApiRequestFactory.cs
@@ -24,6 +24,7 @@ namespace StopWatch
         IRestRequest CreateGetFavoriteFiltersRequest();
         IRestRequest CreateGetIssuesByJQLRequest(string jql);
         IRestRequest CreateGetIssueSummaryRequest(string key);
+        IRestRequest CreateGetIssueTimetrackingRequest(string key);
         IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment, EstimateUpdateMethods adjustmentMethod, string adjustmentValue);
         IRestRequest CreatePostCommentRequest(string key, string comment);
         IRestRequest CreateAuthenticateRequest(string username, string password);

--- a/source/StopWatch/Jira/IJiraApiRequestFactory.cs
+++ b/source/StopWatch/Jira/IJiraApiRequestFactory.cs
@@ -24,7 +24,7 @@ namespace StopWatch
         IRestRequest CreateGetFavoriteFiltersRequest();
         IRestRequest CreateGetIssuesByJQLRequest(string jql);
         IRestRequest CreateGetIssueSummaryRequest(string key);
-        IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment);
+        IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment, EstimateUpdateMethods adjustmentMethod, string adjustmentValue);
         IRestRequest CreatePostCommentRequest(string key, string comment);
         IRestRequest CreateAuthenticateRequest(string username, string password);
         IRestRequest CreateReAuthenticateRequest();

--- a/source/StopWatch/Jira/JiraApiRequestFactory.cs
+++ b/source/StopWatch/Jira/JiraApiRequestFactory.cs
@@ -61,7 +61,7 @@ namespace StopWatch
         }
 
 
-        public IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment)
+        public IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment, EstimateUpdateMethods adjustmentMethod, string adjustmentValue)
         {
             var request = restRequestFactory.Create(String.Format("/rest/api/2/issue/{0}/worklog", key.Trim()), Method.POST);
             request.RequestFormat = DataFormat.Json;
@@ -72,6 +72,22 @@ namespace StopWatch
                     comment = comment
                 }
             );
+            switch(adjustmentMethod) {
+                case EstimateUpdateMethods.Leave:
+                    request.AddQueryParameter("adjustEstimate", "leave");
+                    break;
+                case EstimateUpdateMethods.SetTo:
+                    request.AddQueryParameter("adjustEstimate", "new");
+                    request.AddQueryParameter("newEstimate", adjustmentValue);
+                    break;
+                case EstimateUpdateMethods.ManualDecrease:
+                    request.AddQueryParameter("adjustEstimate", "manual");
+                    request.AddQueryParameter("reduceBy", adjustmentValue);
+                    break;
+                case EstimateUpdateMethods.Auto:
+                    request.AddQueryParameter("adjustEstimate", "auto");
+                    break;
+            }
             return request;
         }
 

--- a/source/StopWatch/Jira/JiraApiRequestFactory.cs
+++ b/source/StopWatch/Jira/JiraApiRequestFactory.cs
@@ -60,6 +60,12 @@ namespace StopWatch
             return request;
         }
 
+        public IRestRequest CreateGetIssueTimetrackingRequest(string key)
+        {
+            var request = restRequestFactory.Create(String.Format("/rest/api/2/issue/{0}?fields=timetracking", key.Trim()), Method.GET);
+            return request;
+        }
+
 
         public IRestRequest CreatePostWorklogRequest(string key, DateTimeOffset started, TimeSpan time, string comment, EstimateUpdateMethods adjustmentMethod, string adjustmentValue)
         {

--- a/source/StopWatch/Jira/JiraClient.cs
+++ b/source/StopWatch/Jira/JiraClient.cs
@@ -109,6 +109,19 @@ namespace StopWatch
             }
         }
 
+        public TimetrackingFields GetIssueTimetracking(string key)
+        {
+            var request = jiraApiRequestFactory.CreateGetIssueTimetrackingRequest(key);
+            try
+            {
+                return jiraApiRequester.DoAuthenticatedRequest<Issue>(request).Fields.Timetracking;
+            }
+            catch (RequestDeniedException)
+            {
+                return null;
+            }
+        }
+
 
         public bool PostWorklog(string key, TimeSpan time, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {

--- a/source/StopWatch/Jira/JiraClient.cs
+++ b/source/StopWatch/Jira/JiraClient.cs
@@ -110,10 +110,10 @@ namespace StopWatch
         }
 
 
-        public bool PostWorklog(string key, TimeSpan time, string comment)
+        public bool PostWorklog(string key, TimeSpan time, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {
             var started = DateTimeOffset.UtcNow.Subtract(time);
-            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment);
+            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment, estimateUpdateMethod, estimateUpdateValue);
             try
             {
                 jiraApiRequester.DoAuthenticatedRequest<object>(request);

--- a/source/StopWatch/JiraApi/IssueFields.cs
+++ b/source/StopWatch/JiraApi/IssueFields.cs
@@ -18,5 +18,12 @@ namespace StopWatch
     internal class IssueFields
     {
         public string Summary { get; set; }
+        public TimetrackingFields Timetracking { get; set; }
+    }
+
+    internal class TimetrackingFields
+    {
+        public string RemainingEstimate { get; set; }
+        public int RemainingEstimateSeconds { get; set; }
     }
 }

--- a/source/StopWatch/MainForm.cs
+++ b/source/StopWatch/MainForm.cs
@@ -172,6 +172,8 @@ namespace StopWatch
                         };
                         issueControl.WatchTimer.SetState(timerState);
                         issueControl.Comment = persistedIssue.Comment;
+                        issueControl.EstimateUpdateMethod = persistedIssue.EstimateUpdateMethod;
+                        issueControl.EstimateUpdateValue = persistedIssue.EstimateUpdateValue;
                     }
                 }
                 i++;
@@ -401,7 +403,9 @@ namespace StopWatch
                     TimerRunning = timerState.Running,
                     StartTime = timerState.StartTime,
                     TotalTime = timerState.TotalTime,
-                    Comment = issueControl.Comment
+                    Comment = issueControl.Comment,
+                    EstimateUpdateMethod = issueControl.EstimateUpdateMethod,
+                    EstimateUpdateValue = issueControl.EstimateUpdateValue
                 };
 
                 settings.PersistedIssues.Add(persistedIssue);

--- a/source/StopWatch/NativeMethods.cs
+++ b/source/StopWatch/NativeMethods.cs
@@ -29,5 +29,15 @@ namespace StopWatch
 
         [DllImport("user32")]
         public static extern int RegisterWindowMessage(string message);
+
+
+    }
+
+    public enum EstimateUpdateMethods
+    {
+        Auto,
+        Leave,
+        SetTo,
+        ManualDecrease
     }
 }

--- a/source/StopWatch/PersistedIssue.cs
+++ b/source/StopWatch/PersistedIssue.cs
@@ -25,5 +25,7 @@ namespace StopWatch
         public DateTime StartTime { get; set; }
         public TimeSpan TotalTime { get; set; }
         public string Comment { get; set; }
+        public EstimateUpdateMethods EstimateUpdateMethod { get; set; }
+        public string EstimateUpdateValue { get; set; }
     }
 }

--- a/source/StopWatch/Properties/Settings.Designer.cs
+++ b/source/StopWatch/Properties/Settings.Designer.cs
@@ -191,5 +191,17 @@ namespace StopWatch.Properties
                 this["PostWorklogComment"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool AllowManualEstimateAdjustments {
+            get {
+                return ((bool)(this["AllowManualEstimateAdjustments"]));
+            }
+            set {
+                this["AllowManualEstimateAdjustments"] = value;
+            }
+        }
     }
 }

--- a/source/StopWatch/Properties/Settings.settings
+++ b/source/StopWatch/Properties/Settings.settings
@@ -44,5 +44,8 @@
     <Setting Name="PostWorklogComment" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="AllowManualEstimateAdjustments" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/source/StopWatch/Settings.cs
+++ b/source/StopWatch/Settings.cs
@@ -49,6 +49,7 @@ namespace StopWatch
         public bool MinimizeToTray { get; set; }
         public int IssueCount { get; set; }
         public bool AllowMultipleTimers { get; set; }
+        public bool AllowManualEstimateAdjustments { get; set; }
 
         public SaveTimerSetting SaveTimerState { get; set; }
         public PauseAndResumeSetting PauseOnSessionLock { get; set; }
@@ -95,6 +96,8 @@ namespace StopWatch
             this.PersistedIssues = ReadIssues(Properties.Settings.Default.PersistedIssues);
 
             this.AllowMultipleTimers = Properties.Settings.Default.AllowMultipleTimers;
+
+            this.AllowManualEstimateAdjustments = Properties.Settings.Default.AllowManualEstimateAdjustments;
         }
 
 
@@ -131,6 +134,8 @@ namespace StopWatch
             Properties.Settings.Default.PersistedIssues = WriteIssues(this.PersistedIssues);
 
             Properties.Settings.Default.AllowMultipleTimers = this.AllowMultipleTimers;
+
+            Properties.Settings.Default.AllowManualEstimateAdjustments = this.AllowManualEstimateAdjustments;
 
             Properties.Settings.Default.Save();
         }

--- a/source/StopWatch/SettingsForm.Designer.cs
+++ b/source/StopWatch/SettingsForm.Designer.cs
@@ -43,7 +43,6 @@ namespace StopWatch
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsForm));
             this.lblJiraBaseUrl = new System.Windows.Forms.Label();
             this.tbJiraBaseUrl = new System.Windows.Forms.TextBox();
             this.lblIssueCount = new System.Windows.Forms.Label();
@@ -63,6 +62,7 @@ namespace StopWatch
             this.cbAllowMultipleTimers = new System.Windows.Forms.CheckBox();
             this.cbPostWorklogComment = new System.Windows.Forms.ComboBox();
             this.lblPostWorklogComment = new System.Windows.Forms.Label();
+            this.cbAllowManualEstimateAdjustments = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.numIssueCount)).BeginInit();
             this.SuspendLayout();
             // 
@@ -131,7 +131,7 @@ namespace StopWatch
             // 
             this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOk.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnOk.Location = new System.Drawing.Point(255, 298);
+            this.btnOk.Location = new System.Drawing.Point(255, 319);
             this.btnOk.Margin = new System.Windows.Forms.Padding(2);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(56, 22);
@@ -142,7 +142,7 @@ namespace StopWatch
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(316, 298);
+            this.btnCancel.Location = new System.Drawing.Point(316, 319);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(2);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(56, 22);
@@ -160,7 +160,7 @@ namespace StopWatch
             // 
             // btnAbout
             // 
-            this.btnAbout.Location = new System.Drawing.Point(11, 298);
+            this.btnAbout.Location = new System.Drawing.Point(11, 319);
             this.btnAbout.Margin = new System.Windows.Forms.Padding(2);
             this.btnAbout.Name = "btnAbout";
             this.btnAbout.Size = new System.Drawing.Size(56, 22);
@@ -209,7 +209,7 @@ namespace StopWatch
             // splitter3
             // 
             this.splitter3.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.splitter3.Location = new System.Drawing.Point(12, 287);
+            this.splitter3.Location = new System.Drawing.Point(12, 308);
             this.splitter3.Name = "splitter3";
             this.splitter3.Size = new System.Drawing.Size(360, 2);
             this.splitter3.TabIndex = 16;
@@ -258,13 +258,25 @@ namespace StopWatch
             this.lblPostWorklogComment.TabIndex = 18;
             this.lblPostWorklogComment.Text = "How to post the worklog comment";
             // 
+            // cbAllowManualEstimateAdjustments
+            // 
+            this.cbAllowManualEstimateAdjustments.AutoSize = true;
+            this.cbAllowManualEstimateAdjustments.Location = new System.Drawing.Point(113, 285);
+            this.cbAllowManualEstimateAdjustments.Margin = new System.Windows.Forms.Padding(2);
+            this.cbAllowManualEstimateAdjustments.Name = "cbAllowManualEstimateAdjustments";
+            this.cbAllowManualEstimateAdjustments.Size = new System.Drawing.Size(200, 17);
+            this.cbAllowManualEstimateAdjustments.TabIndex = 20;
+            this.cbAllowManualEstimateAdjustments.Text = "Allow control over remaining estimate";
+            this.cbAllowManualEstimateAdjustments.UseVisualStyleBackColor = true;
+            // 
             // SettingsForm
             // 
             this.AcceptButton = this.btnOk;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(383, 330);
+            this.ClientSize = new System.Drawing.Size(383, 352);
+            this.Controls.Add(this.cbAllowManualEstimateAdjustments);
             this.Controls.Add(this.cbPostWorklogComment);
             this.Controls.Add(this.lblPostWorklogComment);
             this.Controls.Add(this.cbAllowMultipleTimers);
@@ -284,7 +296,7 @@ namespace StopWatch
             this.Controls.Add(this.lblIssueCount);
             this.Controls.Add(this.tbJiraBaseUrl);
             this.Controls.Add(this.lblJiraBaseUrl);
-            this.Icon = Properties.Resources.stopwatchicon;
+            this.Icon = global::StopWatch.Properties.Resources.stopwatchicon;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "SettingsForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
@@ -317,5 +329,6 @@ namespace StopWatch
         private System.Windows.Forms.CheckBox cbAllowMultipleTimers;
         private System.Windows.Forms.ComboBox cbPostWorklogComment;
         private System.Windows.Forms.Label lblPostWorklogComment;
+        private System.Windows.Forms.CheckBox cbAllowManualEstimateAdjustments;
     }
 }

--- a/source/StopWatch/SettingsForm.cs
+++ b/source/StopWatch/SettingsForm.cs
@@ -42,6 +42,7 @@ namespace StopWatch
             cbAlwaysOnTop.Checked = this.settings.AlwaysOnTop;
             cbMinimizeToTray.Checked = this.settings.MinimizeToTray;
             cbAllowMultipleTimers.Checked = this.settings.AllowMultipleTimers;
+            cbAllowManualEstimateAdjustments.Checked = this.settings.AllowManualEstimateAdjustments;
 
             cbSaveTimerState.DisplayMember = "Text";
             cbSaveTimerState.ValueMember = "Value";
@@ -86,6 +87,7 @@ namespace StopWatch
                 this.settings.AlwaysOnTop = cbAlwaysOnTop.Checked;
                 this.settings.MinimizeToTray = cbMinimizeToTray.Checked;
                 this.settings.AllowMultipleTimers = cbAllowMultipleTimers.Checked;
+                this.settings.AllowManualEstimateAdjustments = cbAllowManualEstimateAdjustments.Checked;
 
                 this.settings.SaveTimerState = (SaveTimerSetting)cbSaveTimerState.SelectedValue;
                 this.settings.PauseOnSessionLock = (PauseAndResumeSetting)cbPauseOnSessionLock.SelectedValue;

--- a/source/StopWatch/WorklogForm.Designer.cs
+++ b/source/StopWatch/WorklogForm.Designer.cs
@@ -53,11 +53,11 @@ namespace StopWatch
             this.btnSave = new System.Windows.Forms.Button();
             this.rdEstimateAdjustAuto = new System.Windows.Forms.RadioButton();
             this.gbRemainingEstimate = new System.Windows.Forms.GroupBox();
+            this.tbReduceBy = new System.Windows.Forms.TextBox();
             this.tbSetTo = new System.Windows.Forms.TextBox();
             this.rdEstimateAdjustManualDecrease = new System.Windows.Forms.RadioButton();
             this.rdEstimateAdjustSetTo = new System.Windows.Forms.RadioButton();
             this.rdEstimateAdjustLeave = new System.Windows.Forms.RadioButton();
-            this.tbReduceBy = new System.Windows.Forms.TextBox();
             this.gbRemainingEstimate.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -127,21 +127,6 @@ namespace StopWatch
             this.btnSave.Text = "Sa&ve for later";
             this.btnSave.UseVisualStyleBackColor = true;
             // 
-            // gbRemainingEstimate
-            // 
-            this.gbRemainingEstimate.Controls.Add(this.tbReduceBy);
-            this.gbRemainingEstimate.Controls.Add(this.tbSetTo);
-            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustManualDecrease);
-            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustSetTo);
-            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustLeave);
-            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustAuto);
-            this.gbRemainingEstimate.Location = new System.Drawing.Point(14, 174);
-            this.gbRemainingEstimate.Name = "gbRemainingEstimate";
-            this.gbRemainingEstimate.Size = new System.Drawing.Size(299, 113);
-            this.gbRemainingEstimate.TabIndex = 2;
-            this.gbRemainingEstimate.TabStop = false;
-            this.gbRemainingEstimate.Text = "Remaining Estimate";            
-            // 
             // rdEstimateAdjustAuto
             // 
             this.rdEstimateAdjustAuto.AutoSize = true;
@@ -156,29 +141,32 @@ namespace StopWatch
             this.rdEstimateAdjustAuto.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
             this.rdEstimateAdjustAuto.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustAuto_KeyDown);
             // 
-            // rdEstimateAdjustLeave
+            // gbRemainingEstimate
             // 
-            this.rdEstimateAdjustLeave.AutoSize = true;
-            this.rdEstimateAdjustLeave.Location = new System.Drawing.Point(8, 39);
-            this.rdEstimateAdjustLeave.Name = "rdEstimateAdjustLeave";
-            this.rdEstimateAdjustLeave.Size = new System.Drawing.Size(85, 17);
-            this.rdEstimateAdjustLeave.TabIndex = 3;
-            this.rdEstimateAdjustLeave.Text = "&Leave Alone";
-            this.rdEstimateAdjustLeave.UseVisualStyleBackColor = true;
-            this.rdEstimateAdjustLeave.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
-            this.rdEstimateAdjustLeave.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustLeave_KeyDown);
+            this.gbRemainingEstimate.Controls.Add(this.tbReduceBy);
+            this.gbRemainingEstimate.Controls.Add(this.tbSetTo);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustManualDecrease);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustSetTo);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustLeave);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustAuto);
+            this.gbRemainingEstimate.Location = new System.Drawing.Point(14, 174);
+            this.gbRemainingEstimate.Name = "gbRemainingEstimate";
+            this.gbRemainingEstimate.Size = new System.Drawing.Size(299, 113);
+            this.gbRemainingEstimate.TabIndex = 2;
+            this.gbRemainingEstimate.TabStop = false;
+            this.gbRemainingEstimate.Text = "Remaining Estimate";
+            this.gbRemainingEstimate.Visible = false;
             // 
-            // rdEstimateAdjustSetTo
+            // tbReduceBy
             // 
-            this.rdEstimateAdjustSetTo.AutoSize = true;
-            this.rdEstimateAdjustSetTo.Location = new System.Drawing.Point(8, 64);
-            this.rdEstimateAdjustSetTo.Name = "rdEstimateAdjustSetTo";
-            this.rdEstimateAdjustSetTo.Size = new System.Drawing.Size(57, 17);
-            this.rdEstimateAdjustSetTo.TabIndex = 4;
-            this.rdEstimateAdjustSetTo.Text = "&Set To";
-            this.rdEstimateAdjustSetTo.UseVisualStyleBackColor = true;
-            this.rdEstimateAdjustSetTo.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
-            this.rdEstimateAdjustSetTo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustSetTo_KeyDown);
+            this.tbReduceBy.Enabled = false;
+            this.tbReduceBy.Location = new System.Drawing.Point(160, 87);
+            this.tbReduceBy.Name = "tbReduceBy";
+            this.tbReduceBy.Size = new System.Drawing.Size(133, 20);
+            this.tbReduceBy.TabIndex = 7;
+            this.tbReduceBy.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyDown);
+            this.tbReduceBy.KeyUp += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyUp);
+            this.tbReduceBy.Validating += new System.ComponentModel.CancelEventHandler(this.tbReduceBy_Validating);
             // 
             // tbSetTo
             // 
@@ -203,21 +191,35 @@ namespace StopWatch
             this.rdEstimateAdjustManualDecrease.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
             this.rdEstimateAdjustManualDecrease.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustManualDecrease_KeyDown);
             // 
-            // tbReduceBy
+            // rdEstimateAdjustSetTo
             // 
-            this.tbReduceBy.Enabled = false;
-            this.tbReduceBy.Location = new System.Drawing.Point(160, 87);
-            this.tbReduceBy.Name = "tbReduceBy";
-            this.tbReduceBy.Size = new System.Drawing.Size(133, 20);
-            this.tbReduceBy.TabIndex = 7;
-            this.tbReduceBy.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyDown);
-            this.tbReduceBy.KeyUp += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyUp);
-            this.tbReduceBy.Validating += new System.ComponentModel.CancelEventHandler(this.tbReduceBy_Validating);
+            this.rdEstimateAdjustSetTo.AutoSize = true;
+            this.rdEstimateAdjustSetTo.Location = new System.Drawing.Point(8, 64);
+            this.rdEstimateAdjustSetTo.Name = "rdEstimateAdjustSetTo";
+            this.rdEstimateAdjustSetTo.Size = new System.Drawing.Size(57, 17);
+            this.rdEstimateAdjustSetTo.TabIndex = 4;
+            this.rdEstimateAdjustSetTo.Text = "&Set To";
+            this.rdEstimateAdjustSetTo.UseVisualStyleBackColor = true;
+            this.rdEstimateAdjustSetTo.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
+            this.rdEstimateAdjustSetTo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustSetTo_KeyDown);
+            // 
+            // rdEstimateAdjustLeave
+            // 
+            this.rdEstimateAdjustLeave.AutoSize = true;
+            this.rdEstimateAdjustLeave.Location = new System.Drawing.Point(8, 39);
+            this.rdEstimateAdjustLeave.Name = "rdEstimateAdjustLeave";
+            this.rdEstimateAdjustLeave.Size = new System.Drawing.Size(85, 17);
+            this.rdEstimateAdjustLeave.TabIndex = 3;
+            this.rdEstimateAdjustLeave.Text = "&Leave Alone";
+            this.rdEstimateAdjustLeave.UseVisualStyleBackColor = true;
+            this.rdEstimateAdjustLeave.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
+            this.rdEstimateAdjustLeave.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustLeave_KeyDown);
             // 
             // WorklogForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.CancelButton = this.btnCancel;
             this.ClientSize = new System.Drawing.Size(321, 341);
             this.Controls.Add(this.gbRemainingEstimate);

--- a/source/StopWatch/WorklogForm.Designer.cs
+++ b/source/StopWatch/WorklogForm.Designer.cs
@@ -208,9 +208,9 @@ namespace StopWatch
             this.rdEstimateAdjustLeave.AutoSize = true;
             this.rdEstimateAdjustLeave.Location = new System.Drawing.Point(8, 39);
             this.rdEstimateAdjustLeave.Name = "rdEstimateAdjustLeave";
-            this.rdEstimateAdjustLeave.Size = new System.Drawing.Size(85, 17);
+            this.rdEstimateAdjustLeave.Size = new System.Drawing.Size(114, 17);
             this.rdEstimateAdjustLeave.TabIndex = 3;
-            this.rdEstimateAdjustLeave.Text = "&Leave Alone";
+            this.rdEstimateAdjustLeave.Text = "&Leave Unchanged";
             this.rdEstimateAdjustLeave.UseVisualStyleBackColor = true;
             this.rdEstimateAdjustLeave.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
             this.rdEstimateAdjustLeave.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustLeave_KeyDown);
@@ -251,10 +251,10 @@ namespace StopWatch
         private System.Windows.Forms.Button btnSave;
         private System.Windows.Forms.RadioButton rdEstimateAdjustAuto;
         private System.Windows.Forms.GroupBox gbRemainingEstimate;
-        private System.Windows.Forms.RadioButton rdEstimateAdjustLeave;
         private RadioButton rdEstimateAdjustManualDecrease;
         private RadioButton rdEstimateAdjustSetTo;
         private TextBox tbSetTo;
         private TextBox tbReduceBy;
+        public RadioButton rdEstimateAdjustLeave;
     }
 }

--- a/source/StopWatch/WorklogForm.Designer.cs
+++ b/source/StopWatch/WorklogForm.Designer.cs
@@ -104,6 +104,7 @@ namespace StopWatch
             this.btnOk.TabIndex = 8;
             this.btnOk.Text = "Su&bmit";
             this.btnOk.UseVisualStyleBackColor = true;
+            this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
             // 
             // lblInfo
             // 
@@ -187,6 +188,7 @@ namespace StopWatch
             this.tbSetTo.Size = new System.Drawing.Size(133, 20);
             this.tbSetTo.TabIndex = 6;
             this.tbSetTo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbSetTo_KeyDown);
+            this.tbSetTo.Validating += new System.ComponentModel.CancelEventHandler(this.tbSetTo_Validating);
             // 
             // rdEstimateAdjustManualDecrease
             // 
@@ -208,6 +210,7 @@ namespace StopWatch
             this.tbReduceBy.Size = new System.Drawing.Size(133, 20);
             this.tbReduceBy.TabIndex = 7;
             this.tbReduceBy.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyDown);
+            this.tbReduceBy.Validating += new System.ComponentModel.CancelEventHandler(this.tbReduceBy_Validating);
             // 
             // WorklogForm
             // 

--- a/source/StopWatch/WorklogForm.Designer.cs
+++ b/source/StopWatch/WorklogForm.Designer.cs
@@ -188,6 +188,7 @@ namespace StopWatch
             this.tbSetTo.Size = new System.Drawing.Size(133, 20);
             this.tbSetTo.TabIndex = 6;
             this.tbSetTo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbSetTo_KeyDown);
+            this.tbSetTo.KeyUp += new System.Windows.Forms.KeyEventHandler(this.tbSetTo_KeyUp);
             this.tbSetTo.Validating += new System.ComponentModel.CancelEventHandler(this.tbSetTo_Validating);
             // 
             // rdEstimateAdjustManualDecrease
@@ -210,6 +211,7 @@ namespace StopWatch
             this.tbReduceBy.Size = new System.Drawing.Size(133, 20);
             this.tbReduceBy.TabIndex = 7;
             this.tbReduceBy.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyDown);
+            this.tbReduceBy.KeyUp += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyUp);
             this.tbReduceBy.Validating += new System.ComponentModel.CancelEventHandler(this.tbReduceBy_Validating);
             // 
             // WorklogForm

--- a/source/StopWatch/WorklogForm.Designer.cs
+++ b/source/StopWatch/WorklogForm.Designer.cs
@@ -1,4 +1,5 @@
-﻿/**************************************************************************
+﻿using System;
+/**************************************************************************
 Copyright 2016 Carsten Gehling
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 **************************************************************************/
+using System.Windows.Forms;
 namespace StopWatch
 {
     partial class WorklogForm
@@ -49,6 +51,14 @@ namespace StopWatch
             this.btnOk = new System.Windows.Forms.Button();
             this.lblInfo = new System.Windows.Forms.Label();
             this.btnSave = new System.Windows.Forms.Button();
+            this.rdEstimateAdjustAuto = new System.Windows.Forms.RadioButton();
+            this.gbRemainingEstimate = new System.Windows.Forms.GroupBox();
+            this.tbSetTo = new System.Windows.Forms.TextBox();
+            this.rdEstimateAdjustManualDecrease = new System.Windows.Forms.RadioButton();
+            this.rdEstimateAdjustSetTo = new System.Windows.Forms.RadioButton();
+            this.rdEstimateAdjustLeave = new System.Windows.Forms.RadioButton();
+            this.tbReduceBy = new System.Windows.Forms.TextBox();
+            this.gbRemainingEstimate.SuspendLayout();
             this.SuspendLayout();
             // 
             // lblComment
@@ -57,7 +67,7 @@ namespace StopWatch
             this.lblComment.Location = new System.Drawing.Point(9, 7);
             this.lblComment.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblComment.Name = "lblComment";
-            this.lblComment.Size = new System.Drawing.Size(205, 13);
+            this.lblComment.Size = new System.Drawing.Size(206, 13);
             this.lblComment.TabIndex = 0;
             this.lblComment.Text = "Add a Comment to your work log (optional)";
             // 
@@ -75,11 +85,11 @@ namespace StopWatch
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(254, 186);
+            this.btnCancel.Location = new System.Drawing.Point(254, 312);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(2);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(56, 23);
-            this.btnCancel.TabIndex = 3;
+            this.btnCancel.TabIndex = 9;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             // 
@@ -87,18 +97,18 @@ namespace StopWatch
             // 
             this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOk.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnOk.Location = new System.Drawing.Point(193, 186);
+            this.btnOk.Location = new System.Drawing.Point(193, 312);
             this.btnOk.Margin = new System.Windows.Forms.Padding(2);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(56, 23);
-            this.btnOk.TabIndex = 2;
+            this.btnOk.TabIndex = 8;
             this.btnOk.Text = "Su&bmit";
             this.btnOk.UseVisualStyleBackColor = true;
             // 
             // lblInfo
             // 
             this.lblInfo.AutoSize = true;
-            this.lblInfo.Location = new System.Drawing.Point(11, 171);
+            this.lblInfo.Location = new System.Drawing.Point(11, 292);
             this.lblInfo.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblInfo.Name = "lblInfo";
             this.lblInfo.Size = new System.Drawing.Size(137, 13);
@@ -108,43 +118,136 @@ namespace StopWatch
             // btnSave
             // 
             this.btnSave.DialogResult = System.Windows.Forms.DialogResult.Yes;
-            this.btnSave.Location = new System.Drawing.Point(11, 186);
+            this.btnSave.Location = new System.Drawing.Point(11, 312);
             this.btnSave.Margin = new System.Windows.Forms.Padding(2);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(83, 23);
-            this.btnSave.TabIndex = 5;
+            this.btnSave.TabIndex = 10;
             this.btnSave.Text = "Sa&ve for later";
             this.btnSave.UseVisualStyleBackColor = true;
+            // 
+            // gbRemainingEstimate
+            // 
+            this.gbRemainingEstimate.Controls.Add(this.tbReduceBy);
+            this.gbRemainingEstimate.Controls.Add(this.tbSetTo);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustManualDecrease);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustSetTo);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustLeave);
+            this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustAuto);
+            this.gbRemainingEstimate.Location = new System.Drawing.Point(14, 174);
+            this.gbRemainingEstimate.Name = "gbRemainingEstimate";
+            this.gbRemainingEstimate.Size = new System.Drawing.Size(299, 113);
+            this.gbRemainingEstimate.TabIndex = 2;
+            this.gbRemainingEstimate.TabStop = false;
+            this.gbRemainingEstimate.Text = "Remaining Estimate";            
+            // 
+            // rdEstimateAdjustAuto
+            // 
+            this.rdEstimateAdjustAuto.AutoSize = true;
+            this.rdEstimateAdjustAuto.Checked = true;
+            this.rdEstimateAdjustAuto.Location = new System.Drawing.Point(8, 15);
+            this.rdEstimateAdjustAuto.Name = "rdEstimateAdjustAuto";
+            this.rdEstimateAdjustAuto.Size = new System.Drawing.Size(119, 17);
+            this.rdEstimateAdjustAuto.TabIndex = 2;
+            this.rdEstimateAdjustAuto.TabStop = true;
+            this.rdEstimateAdjustAuto.Text = "Adjust &Automatically";
+            this.rdEstimateAdjustAuto.UseVisualStyleBackColor = true;
+            this.rdEstimateAdjustAuto.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
+            this.rdEstimateAdjustAuto.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustAuto_KeyDown);
+            // 
+            // rdEstimateAdjustLeave
+            // 
+            this.rdEstimateAdjustLeave.AutoSize = true;
+            this.rdEstimateAdjustLeave.Location = new System.Drawing.Point(8, 39);
+            this.rdEstimateAdjustLeave.Name = "rdEstimateAdjustLeave";
+            this.rdEstimateAdjustLeave.Size = new System.Drawing.Size(85, 17);
+            this.rdEstimateAdjustLeave.TabIndex = 3;
+            this.rdEstimateAdjustLeave.Text = "&Leave Alone";
+            this.rdEstimateAdjustLeave.UseVisualStyleBackColor = true;
+            this.rdEstimateAdjustLeave.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
+            this.rdEstimateAdjustLeave.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustLeave_KeyDown);
+            // 
+            // rdEstimateAdjustSetTo
+            // 
+            this.rdEstimateAdjustSetTo.AutoSize = true;
+            this.rdEstimateAdjustSetTo.Location = new System.Drawing.Point(8, 64);
+            this.rdEstimateAdjustSetTo.Name = "rdEstimateAdjustSetTo";
+            this.rdEstimateAdjustSetTo.Size = new System.Drawing.Size(57, 17);
+            this.rdEstimateAdjustSetTo.TabIndex = 4;
+            this.rdEstimateAdjustSetTo.Text = "&Set To";
+            this.rdEstimateAdjustSetTo.UseVisualStyleBackColor = true;
+            this.rdEstimateAdjustSetTo.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
+            this.rdEstimateAdjustSetTo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustSetTo_KeyDown);
+            // 
+            // tbSetTo
+            // 
+            this.tbSetTo.Enabled = false;
+            this.tbSetTo.Location = new System.Drawing.Point(160, 63);
+            this.tbSetTo.Name = "tbSetTo";
+            this.tbSetTo.Size = new System.Drawing.Size(133, 20);
+            this.tbSetTo.TabIndex = 6;
+            this.tbSetTo.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbSetTo_KeyDown);
+            // 
+            // rdEstimateAdjustManualDecrease
+            // 
+            this.rdEstimateAdjustManualDecrease.AutoSize = true;
+            this.rdEstimateAdjustManualDecrease.Location = new System.Drawing.Point(8, 88);
+            this.rdEstimateAdjustManualDecrease.Name = "rdEstimateAdjustManualDecrease";
+            this.rdEstimateAdjustManualDecrease.Size = new System.Drawing.Size(78, 17);
+            this.rdEstimateAdjustManualDecrease.TabIndex = 5;
+            this.rdEstimateAdjustManualDecrease.Text = "&Reduce By";
+            this.rdEstimateAdjustManualDecrease.UseVisualStyleBackColor = true;
+            this.rdEstimateAdjustManualDecrease.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
+            this.rdEstimateAdjustManualDecrease.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustManualDecrease_KeyDown);
+            // 
+            // tbReduceBy
+            // 
+            this.tbReduceBy.Enabled = false;
+            this.tbReduceBy.Location = new System.Drawing.Point(160, 87);
+            this.tbReduceBy.Name = "tbReduceBy";
+            this.tbReduceBy.Size = new System.Drawing.Size(133, 20);
+            this.tbReduceBy.TabIndex = 7;
+            this.tbReduceBy.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbReduceBy_KeyDown);
             // 
             // WorklogForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(321, 220);
+            this.ClientSize = new System.Drawing.Size(321, 341);
+            this.Controls.Add(this.gbRemainingEstimate);
             this.Controls.Add(this.btnSave);
             this.Controls.Add(this.lblInfo);
             this.Controls.Add(this.btnOk);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.tbComment);
             this.Controls.Add(this.lblComment);
-            this.Icon = Properties.Resources.stopwatchicon;
+            this.Icon = global::StopWatch.Properties.Resources.stopwatchicon;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "WorklogForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Submit worklog";
+            this.gbRemainingEstimate.ResumeLayout(false);
+            this.gbRemainingEstimate.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
 
         #endregion
-
+        
         private System.Windows.Forms.Label lblComment;
         private System.Windows.Forms.TextBox tbComment;
         private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Button btnOk;
         private System.Windows.Forms.Label lblInfo;
         private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.RadioButton rdEstimateAdjustAuto;
+        private System.Windows.Forms.GroupBox gbRemainingEstimate;
+        private System.Windows.Forms.RadioButton rdEstimateAdjustLeave;
+        private RadioButton rdEstimateAdjustManualDecrease;
+        private RadioButton rdEstimateAdjustSetTo;
+        private TextBox tbSetTo;
+        private TextBox tbReduceBy;
     }
 }

--- a/source/StopWatch/WorklogForm.cs
+++ b/source/StopWatch/WorklogForm.cs
@@ -33,23 +33,37 @@ namespace StopWatch
         {
             get
             {
-                return _estimateUpdateMethod;
+                if (this.AllowManualEstimateAdjustments) 
+                {
+                    return _estimateUpdateMethod;
+                }
+                else 
+                {
+                    return EstimateUpdateMethods.Auto;
+                }
             }
         }
         public string EstimateValue
         {
             get
             {
-                switch(this.estimateUpdateMethod)
+                if (this.AllowManualEstimateAdjustments)
                 {
-                    case EstimateUpdateMethods.SetTo:                       
-                        return this.tbSetTo.Text;
-                    case EstimateUpdateMethods.ManualDecrease:
-                        return this.tbReduceBy.Text;
-                    case EstimateUpdateMethods.Auto:
-                    case EstimateUpdateMethods.Leave:
-                    default:
-                        return null;                        
+                    switch(this.estimateUpdateMethod)
+                    {
+                        case EstimateUpdateMethods.SetTo:                       
+                            return this.tbSetTo.Text;
+                        case EstimateUpdateMethods.ManualDecrease:
+                            return this.tbReduceBy.Text;
+                        case EstimateUpdateMethods.Auto:
+                        case EstimateUpdateMethods.Leave:
+                        default:
+                            return null;                        
+                    }
+                }
+                else
+                {
+                    return null;
                 }
             }
         }
@@ -57,8 +71,9 @@ namespace StopWatch
 
 
         #region public methods
-        public WorklogForm(string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
+        public WorklogForm(bool AllowManualEstimateAdjustments, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {
+            this.AllowManualEstimateAdjustments = AllowManualEstimateAdjustments;
             InitializeComponent();
 
             if (!String.IsNullOrEmpty(comment))
@@ -66,21 +81,46 @@ namespace StopWatch
                 tbComment.Text = String.Format("{0}{0}{1}", Environment.NewLine, comment);
                 tbComment.SelectionStart = 0;
             }
-            switch( estimateUpdateMethod ) {
-                case EstimateUpdateMethods.Auto:
-                    rdEstimateAdjustAuto.Checked = true;
-                    break;
-                case EstimateUpdateMethods.Leave:
-                    rdEstimateAdjustLeave.Checked = true;
-                    break;
-                case EstimateUpdateMethods.SetTo:
-                    rdEstimateAdjustSetTo.Checked = true;
-                    tbSetTo.Text = estimateUpdateValue;
-                    break;
-                case EstimateUpdateMethods.ManualDecrease:
-                    rdEstimateAdjustManualDecrease.Checked = true;
-                    tbReduceBy.Text = estimateUpdateValue;
-                    break;
+            if (this.AllowManualEstimateAdjustments)
+            {
+                this.gbRemainingEstimate.Visible = true;
+                switch( estimateUpdateMethod ) {
+                    case EstimateUpdateMethods.Auto:
+                        rdEstimateAdjustAuto.Checked = true;
+                        break;
+                    case EstimateUpdateMethods.Leave:
+                        rdEstimateAdjustLeave.Checked = true;
+                        break;
+                    case EstimateUpdateMethods.SetTo:
+                        rdEstimateAdjustSetTo.Checked = true;
+                        tbSetTo.Text = estimateUpdateValue;
+                        break;
+                    case EstimateUpdateMethods.ManualDecrease:
+                        rdEstimateAdjustManualDecrease.Checked = true;
+                        tbReduceBy.Text = estimateUpdateValue;
+                        break;
+                }
+            }
+            else
+            {
+                this.lblInfo.Location = new Point(
+                    this.lblInfo.Location.X,
+                    this.lblInfo.Location.Y - this.gbRemainingEstimate.Height
+                );
+                this.btnSave.Location = new Point(
+                    this.btnSave.Location.X,
+                    this.btnSave.Location.Y - this.gbRemainingEstimate.Height
+                );
+                this.btnOk.Location = new Point(
+                    this.btnOk.Location.X,
+                    this.btnOk.Location.Y - this.gbRemainingEstimate.Height
+                );
+                this.btnCancel.Location = new Point(
+                    this.btnCancel.Location.X,
+                    this.btnCancel.Location.Y - this.gbRemainingEstimate.Height
+                );
+                this.Height -= this.gbRemainingEstimate.Height;
+
             }
         }
         #endregion
@@ -93,6 +133,7 @@ namespace StopWatch
         private EstimateUpdateMethods _estimateUpdateMethod = EstimateUpdateMethods.Auto;
         private bool tbSetToInvalid = false;
         private bool tbReduceByInvalid = false;
+        private bool AllowManualEstimateAdjustments;
 
         #endregion
 

--- a/source/StopWatch/WorklogForm.cs
+++ b/source/StopWatch/WorklogForm.cs
@@ -15,6 +15,7 @@ limitations under the License.
 **************************************************************************/
 using System;
 using System.Windows.Forms;
+using System.Drawing;
 
 namespace StopWatch
 {
@@ -123,13 +124,31 @@ namespace StopWatch
         {
             submit_if_ctrl_enter(e);
         }
+        private void tbSetTo_Validating(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            if (!ValidateTimeInput(tbSetTo))
+            {
+                e.Cancel = true;                
+            }
+        }
+        private void tbReduceBy_Validating(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            if (!ValidateTimeInput(tbReduceBy))
+            {
+                e.Cancel = true;
+            }
+        }
 
         private void submit_if_ctrl_enter(KeyEventArgs e)
         {
             if (e.KeyData == (Keys.Control | Keys.Enter))
             {
                 DialogResult = DialogResult.OK;
-                Close();
+                post_time_and_close();
+                if (DialogResult == DialogResult.OK)
+                {
+                    Close();
+                }
             }
         }
 
@@ -164,6 +183,82 @@ namespace StopWatch
             }
         }
 
+        private void btnOk_Click(object sender, EventArgs e)
+        {
+            post_time_and_close();
+        }
+
+        private void post_time_and_close()
+        {
+            if (!ValidateAllInputs())
+            {
+                DialogResult = DialogResult.None;
+                return;
+            }            
+        }
         #endregion       
+
+        #region private utility methods
+        /// <summary>
+        /// Validates the required inputs.  Returns
+        /// </summary>
+        /// <returns></returns>
+        private bool ValidateAllInputs()
+        {
+            Boolean AllValid = true;
+            switch(estimateUpdateMethod) {
+                case EstimateUpdateMethods.SetTo: 
+                    if (!ValidateTimeInput(tbSetTo))
+                    {
+                        AllValid = false;
+                    }
+                    break;
+                case EstimateUpdateMethods.ManualDecrease:
+                    if (!ValidateTimeInput(tbReduceBy))
+                    {
+                        AllValid = false;
+                    }
+                    break;
+            }
+
+            return AllValid;
+        }
+        /// <summary>
+        /// Checks if the time entered in the submitted textbox is valid
+        /// Marks it as invalid if it is not
+        /// </summary>
+        /// <param name="tb"></param>
+        /// <returns></returns>
+        private bool ValidateTimeInput(TextBox tb)
+        {
+            if (tb.Enabled)
+            {
+                if (string.IsNullOrWhiteSpace(tb.Text))
+                {
+                    tb.BackColor = Color.Tomato;
+                    tb.Select();
+                    return false;
+                }
+                else
+                {
+                    TimeSpan? time = JiraTimeHelpers.JiraTimeToTimeSpan(tb.Text);
+                    if (time == null)
+                    {
+                        tb.BackColor = Color.Tomato;
+                        tb.Select(0, tb.Text.Length);
+                        return false;
+                    }
+                    else{
+                        tb.BackColor = SystemColors.Window;
+                        return true;
+                    }
+                }
+            } 
+            else 
+            {
+                return true;
+            }            
+        }
+        #endregion
     }
 }

--- a/source/StopWatch/WorklogForm.cs
+++ b/source/StopWatch/WorklogForm.cs
@@ -67,22 +67,48 @@ namespace StopWatch
                 }
             }
         }
+
+        public string RemainingEstimate
+        {
+            get
+            {
+                return _RemainingEstimate;
+            }
+            set
+            {
+                _RemainingEstimate = value;
+                RemainingEstimateUpdated();
+            }
+        }
+
+        public int RemainingEstimateSeconds
+        {
+            get
+            {
+                return _RemainingEstimateSeconds;
+            }
+            set
+            {
+                _RemainingEstimateSeconds = value;
+                RemainingEstimateUpdated();
+            }
+        }
         #endregion
 
 
         #region public methods
-        public WorklogForm(bool AllowManualEstimateAdjustments, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
-        {
+        public WorklogForm(TimeSpan TimeElapsed, bool AllowManualEstimateAdjustments, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
+        {            
             this.AllowManualEstimateAdjustments = AllowManualEstimateAdjustments;
+            this.TimeElapsed = TimeElapsed;
             InitializeComponent();
-
             if (!String.IsNullOrEmpty(comment))
             {
                 tbComment.Text = String.Format("{0}{0}{1}", Environment.NewLine, comment);
                 tbComment.SelectionStart = 0;
             }
             if (this.AllowManualEstimateAdjustments)
-            {
+            {                
                 this.gbRemainingEstimate.Visible = true;
                 switch( estimateUpdateMethod ) {
                     case EstimateUpdateMethods.Auto:
@@ -134,7 +160,9 @@ namespace StopWatch
         private bool tbSetToInvalid = false;
         private bool tbReduceByInvalid = false;
         private bool AllowManualEstimateAdjustments;
-
+        private string _RemainingEstimate;
+        private int _RemainingEstimateSeconds;
+        private TimeSpan TimeElapsed;
         #endregion
 
         #region private eventhandlers
@@ -264,6 +292,45 @@ namespace StopWatch
         #endregion       
 
         #region private utility methods
+
+        private void RemainingEstimateUpdated()
+        {
+            if (string.IsNullOrWhiteSpace(RemainingEstimate))
+            {
+                rdEstimateAdjustLeave.Text = "&Leave Unchanged bar";
+            }
+            else
+            {
+                rdEstimateAdjustLeave.Text = string.Format("&Leave As {0}", _RemainingEstimate);
+            }
+
+            if( TimeElapsed != null && RemainingEstimateSeconds > 0){
+                rdEstimateAdjustAuto.Text = string.Format("Adjust &Automatically (to {0})", calculatedAdjustedRemainingEstimate());
+            }else {
+                rdEstimateAdjustAuto.Text = "Adjust &Automatically";
+            }
+        }
+
+        private string calculatedAdjustedRemainingEstimate()
+        {
+            
+            int AdjustedRemainingSeconds = RemainingEstimateSeconds - (int)Math.Floor(TimeElapsed.TotalSeconds);
+            if (AdjustedRemainingSeconds > 0)
+            {
+                TimeSpan AdjustedRemaining = new TimeSpan(0, 0, AdjustedRemainingSeconds);
+                return JiraTimeHelpers.TimeSpanToJiraTime(AdjustedRemaining);
+            }
+            else
+            {
+                return "0m";
+            }
+        }
+
+        private void foo(string text)
+        {
+
+        }
+
         /// <summary>
         /// Validates the required inputs.  Returns
         /// </summary>

--- a/source/StopWatch/WorklogForm.cs
+++ b/source/StopWatch/WorklogForm.cs
@@ -28,6 +28,30 @@ namespace StopWatch
                 return tbComment.Text;
             }
         }
+        public EstimateUpdateMethods estimateUpdateMethod
+        {
+            get
+            {
+                return _estimateUpdateMethod;
+            }
+        }
+        public string EstimateValue
+        {
+            get
+            {
+                switch(this.estimateUpdateMethod)
+                {
+                    case EstimateUpdateMethods.SetTo:                       
+                        return this.tbSetTo.Text;
+                    case EstimateUpdateMethods.ManualDecrease:
+                        return this.tbReduceBy.Text;
+                    case EstimateUpdateMethods.Auto:
+                    case EstimateUpdateMethods.Leave:
+                    default:
+                        return null;                        
+                }
+            }
+        }
         #endregion
 
 
@@ -44,9 +68,47 @@ namespace StopWatch
         }
         #endregion
 
+        #region private fields
+        
+        /// <summary>
+        /// Update method for the estimate
+        /// </summary>
+        private EstimateUpdateMethods _estimateUpdateMethod = EstimateUpdateMethods.Auto;
+
+        #endregion
 
         #region private eventhandlers
         private void tbComment_KeyDown(object sender, KeyEventArgs e)
+        {
+            submit_if_ctrl_enter(e);
+        }
+
+        private void tbSetTo_KeyDown(object sender, KeyEventArgs e)
+        {
+            submit_if_ctrl_enter(e);
+        }
+        private void tbReduceBy_KeyDown(object sender, KeyEventArgs e)
+        {
+            submit_if_ctrl_enter(e);
+        }
+        private void rdEstimateAdjustAuto_KeyDown(object sender, KeyEventArgs e)
+        {
+            submit_if_ctrl_enter(e);
+        }
+        private void rdEstimateAdjustLeave_KeyDown(object sender, KeyEventArgs e)
+        {
+            submit_if_ctrl_enter(e);
+        }
+        private void rdEstimateAdjustSetTo_KeyDown(object sender, KeyEventArgs e)
+        {
+            submit_if_ctrl_enter(e);
+        }
+        private void rdEstimateAdjustManualDecrease_KeyDown(object sender, KeyEventArgs e)
+        {
+            submit_if_ctrl_enter(e);
+        }
+
+        private void submit_if_ctrl_enter(KeyEventArgs e)
         {
             if (e.KeyData == (Keys.Control | Keys.Enter))
             {
@@ -54,6 +116,38 @@ namespace StopWatch
                 Close();
             }
         }
-        #endregion
+
+        private void estimateUpdateMethod_changed(object sender, EventArgs e)
+        {
+            RadioButton button = sender as RadioButton;
+            if (button != null && button.Checked)
+            {
+                switch (button.Name)
+                {
+                    case "rdEstimateAdjustAuto":
+                        this._estimateUpdateMethod = EstimateUpdateMethods.Auto;
+                        this.tbSetTo.Enabled = false;
+                        this.tbReduceBy.Enabled = false;
+                        break;
+                    case "rdEstimateAdjustLeave":
+                        this._estimateUpdateMethod = EstimateUpdateMethods.Leave;
+                        this.tbSetTo.Enabled = false;
+                        this.tbReduceBy.Enabled = false;
+                        break;
+                    case "rdEstimateAdjustSetTo":
+                        this._estimateUpdateMethod = EstimateUpdateMethods.SetTo;
+                        this.tbSetTo.Enabled = true;
+                        this.tbReduceBy.Enabled = false;
+                        break;
+                    case "rdEstimateAdjustManualDecrease":
+                        this._estimateUpdateMethod = EstimateUpdateMethods.ManualDecrease;
+                        this.tbSetTo.Enabled = false;
+                        this.tbReduceBy.Enabled = true;
+                        break;
+                }
+            }
+        }
+
+        #endregion       
     }
 }

--- a/source/StopWatch/WorklogForm.cs
+++ b/source/StopWatch/WorklogForm.cs
@@ -126,17 +126,19 @@ namespace StopWatch
         }
         private void tbSetTo_Validating(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            if (!ValidateTimeInput(tbSetTo))
-            {
-                e.Cancel = true;                
-            }
+            // Valdiate but do not set the cancel event
+            // The reason for this is thats etting the cancel event means you can't leave the field,
+            // even to choose a different estimate adjustment option.
+            // So valiate (so the colour updates) but do not cancel
+            ValidateTimeInput(tbSetTo, false);
         }
         private void tbReduceBy_Validating(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            if (!ValidateTimeInput(tbReduceBy))
-            {
-                e.Cancel = true;
-            }
+            // Valdiate but do not set the cancel event
+            // The reason for this is thats etting the cancel event means you can't leave the field,
+            // even to choose a different estimate adjustment option.
+            // So valiate (so the colour updates) but do not cancel
+            ValidateTimeInput(tbReduceBy, false);
         }
 
         private void submit_if_ctrl_enter(KeyEventArgs e)
@@ -162,22 +164,28 @@ namespace StopWatch
                     case "rdEstimateAdjustAuto":
                         this._estimateUpdateMethod = EstimateUpdateMethods.Auto;
                         this.tbSetTo.Enabled = false;
+                        this.tbSetTo.BackColor = SystemColors.Window;
                         this.tbReduceBy.Enabled = false;
+                        this.tbReduceBy.BackColor = SystemColors.Window;
                         break;
                     case "rdEstimateAdjustLeave":
                         this._estimateUpdateMethod = EstimateUpdateMethods.Leave;
                         this.tbSetTo.Enabled = false;
+                        this.tbSetTo.BackColor = SystemColors.Window;
                         this.tbReduceBy.Enabled = false;
+                        this.tbReduceBy.BackColor = SystemColors.Window;
                         break;
                     case "rdEstimateAdjustSetTo":
                         this._estimateUpdateMethod = EstimateUpdateMethods.SetTo;
                         this.tbSetTo.Enabled = true;
                         this.tbReduceBy.Enabled = false;
+                        this.tbReduceBy.BackColor = SystemColors.Window;
                         break;
                     case "rdEstimateAdjustManualDecrease":
                         this._estimateUpdateMethod = EstimateUpdateMethods.ManualDecrease;
                         this.tbSetTo.Enabled = false;
-                        this.tbReduceBy.Enabled = true;
+                        this.tbSetTo.BackColor = SystemColors.Window;
+                        this.tbReduceBy.Enabled = true;                        
                         break;
                 }
             }
@@ -208,13 +216,13 @@ namespace StopWatch
             Boolean AllValid = true;
             switch(estimateUpdateMethod) {
                 case EstimateUpdateMethods.SetTo: 
-                    if (!ValidateTimeInput(tbSetTo))
+                    if (!ValidateTimeInput(tbSetTo, true))
                     {
                         AllValid = false;
                     }
                     break;
                 case EstimateUpdateMethods.ManualDecrease:
-                    if (!ValidateTimeInput(tbReduceBy))
+                    if (!ValidateTimeInput(tbReduceBy, true))
                     {
                         AllValid = false;
                     }
@@ -229,14 +237,17 @@ namespace StopWatch
         /// </summary>
         /// <param name="tb"></param>
         /// <returns></returns>
-        private bool ValidateTimeInput(TextBox tb)
+        private bool ValidateTimeInput(TextBox tb, bool FocusIfInvalid)
         {
             if (tb.Enabled)
             {
                 if (string.IsNullOrWhiteSpace(tb.Text))
                 {
                     tb.BackColor = Color.Tomato;
-                    tb.Select();
+                    if (FocusIfInvalid)
+                    {
+                        tb.Select();
+                    }
                     return false;
                 }
                 else
@@ -245,7 +256,10 @@ namespace StopWatch
                     if (time == null)
                     {
                         tb.BackColor = Color.Tomato;
-                        tb.Select(0, tb.Text.Length);
+                        if (FocusIfInvalid)
+                        {
+                            tb.Select(0, tb.Text.Length);
+                        }
                         return false;
                     }
                     else{

--- a/source/StopWatch/WorklogForm.cs
+++ b/source/StopWatch/WorklogForm.cs
@@ -91,6 +91,8 @@ namespace StopWatch
         /// Update method for the estimate
         /// </summary>
         private EstimateUpdateMethods _estimateUpdateMethod = EstimateUpdateMethods.Auto;
+        private bool tbSetToInvalid = false;
+        private bool tbReduceByInvalid = false;
 
         #endregion
 
@@ -100,9 +102,23 @@ namespace StopWatch
             submit_if_ctrl_enter(e);
         }
 
+        private void tbSetTo_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (tbSetToInvalid)
+            {
+                ValidateTimeInput(tbSetTo, false);
+            }
+        }
         private void tbSetTo_KeyDown(object sender, KeyEventArgs e)
         {
             submit_if_ctrl_enter(e);
+        }
+        private void tbReduceBy_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (tbReduceByInvalid)
+            {
+                ValidateTimeInput(tbReduceBy, false);
+            }
         }
         private void tbReduceBy_KeyDown(object sender, KeyEventArgs e)
         {
@@ -214,17 +230,19 @@ namespace StopWatch
         private bool ValidateAllInputs()
         {
             Boolean AllValid = true;
+            tbSetToInvalid = false;
+            tbReduceByInvalid = false;
             switch(estimateUpdateMethod) {
                 case EstimateUpdateMethods.SetTo: 
                     if (!ValidateTimeInput(tbSetTo, true))
                     {
-                        AllValid = false;
+                        AllValid = false;                        
                     }
                     break;
                 case EstimateUpdateMethods.ManualDecrease:
                     if (!ValidateTimeInput(tbReduceBy, true))
                     {
-                        AllValid = false;
+                        AllValid = false;                        
                     }
                     break;
             }
@@ -239,6 +257,7 @@ namespace StopWatch
         /// <returns></returns>
         private bool ValidateTimeInput(TextBox tb, bool FocusIfInvalid)
         {
+            bool fieldIsValid;
             if (tb.Enabled)
             {
                 if (string.IsNullOrWhiteSpace(tb.Text))
@@ -248,7 +267,7 @@ namespace StopWatch
                     {
                         tb.Select();
                     }
-                    return false;
+                    fieldIsValid = false;
                 }
                 else
                 {
@@ -260,18 +279,29 @@ namespace StopWatch
                         {
                             tb.Select(0, tb.Text.Length);
                         }
-                        return false;
+                        fieldIsValid = false;
                     }
                     else{
                         tb.BackColor = SystemColors.Window;
-                        return true;
+                        fieldIsValid = true;
                     }
                 }
             } 
             else 
             {
-                return true;
-            }            
+                fieldIsValid = true;
+            }
+
+            switch(tb.Name)
+            {
+                case "tbSetTo":
+                    tbSetToInvalid = !fieldIsValid;
+                    break;
+                case "tbReduceBy":
+                    tbReduceByInvalid = !fieldIsValid;
+                    break;
+            }
+            return fieldIsValid;
         }
         #endregion
     }

--- a/source/StopWatch/WorklogForm.cs
+++ b/source/StopWatch/WorklogForm.cs
@@ -56,7 +56,7 @@ namespace StopWatch
 
 
         #region public methods
-        public WorklogForm(string comment)
+        public WorklogForm(string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {
             InitializeComponent();
 
@@ -64,6 +64,22 @@ namespace StopWatch
             {
                 tbComment.Text = String.Format("{0}{0}{1}", Environment.NewLine, comment);
                 tbComment.SelectionStart = 0;
+            }
+            switch( estimateUpdateMethod ) {
+                case EstimateUpdateMethods.Auto:
+                    rdEstimateAdjustAuto.Checked = true;
+                    break;
+                case EstimateUpdateMethods.Leave:
+                    rdEstimateAdjustLeave.Checked = true;
+                    break;
+                case EstimateUpdateMethods.SetTo:
+                    rdEstimateAdjustSetTo.Checked = true;
+                    tbSetTo.Text = estimateUpdateValue;
+                    break;
+                case EstimateUpdateMethods.ManualDecrease:
+                    rdEstimateAdjustManualDecrease.Checked = true;
+                    tbReduceBy.Text = estimateUpdateValue;
+                    break;
             }
         }
         #endregion

--- a/source/StopWatchTest/JiraApiRequestFactoryTest.cs
+++ b/source/StopWatchTest/JiraApiRequestFactoryTest.cs
@@ -69,6 +69,23 @@
             requestFactoryMock.Verify(m => m.Create(String.Format("/rest/api/2/issue/{0}", key.Trim()), Method.GET));
         }
 
+        [Test]
+        public void CreateGetIssueTimetrackingRequestt_CreatesValidRequest()
+        {
+            string key = "FOO-42";
+            var request = jiraApiRequestFactory.CreateGetIssueTimetrackingRequest(key);
+            requestFactoryMock.Verify(m => m.Create(String.Format("/rest/api/2/issue/{0}?fields=timetracking", key), Method.GET));
+        }
+
+
+        [Test]
+        public void CreateGetIssueTimetrackingRequest_RemoveLeadingAndTrailingSpacesFromIssueKey()
+        {
+            string key = "   FOO-42   ";
+            var request = jiraApiRequestFactory.CreateGetIssueTimetrackingRequest(key);
+            requestFactoryMock.Verify(m => m.Create(String.Format("/rest/api/2/issue/{0}?fields=timetracking", key.Trim()), Method.GET));
+        }
+
 
         [Test]
         public void CreatePostWorklogRequest_CreatesValidRequest()

--- a/source/StopWatchTest/JiraApiRequestFactoryTest.cs
+++ b/source/StopWatchTest/JiraApiRequestFactoryTest.cs
@@ -77,7 +77,9 @@
             var started = new DateTimeOffset(2016, 07, 26, 1, 44, 15, TimeSpan.Zero);
             TimeSpan time = new TimeSpan(1, 2, 0);
             string comment = "Sorry for the inconvenience...";
-            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment);
+            StopWatch.EstimateUpdateMethods adjusmentMethod = EstimateUpdateMethods.Auto;
+            string adjustmentValue = "";
+            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment, adjusmentMethod, adjustmentValue);
 
             requestFactoryMock.Verify(m => m.Create(String.Format("/rest/api/2/issue/{0}/worklog", key), Method.POST));
 
@@ -100,7 +102,9 @@
             var started = new DateTimeOffset(2016, 07, 26, 1, 44, 15, TimeSpan.Zero);
             TimeSpan time = new TimeSpan(1, 2, 0);
             string comment = "Sorry for the inconvenience...";
-            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment);
+            StopWatch.EstimateUpdateMethods adjusmentMethod = EstimateUpdateMethods.Auto;
+            string adjustmentValue = "";
+            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment, adjusmentMethod, adjustmentValue);
 
             requestFactoryMock.Verify(m => m.Create(String.Format("/rest/api/2/issue/{0}/worklog", key.Trim()), Method.POST));
         }

--- a/source/StopWatchTest/JiraClientTest.cs
+++ b/source/StopWatchTest/JiraClientTest.cs
@@ -136,7 +136,7 @@
         {
             jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<object>(It.IsAny<IRestRequest>())).Returns(new object());
 
-            Assert.That(jiraClient.PostWorklog("DG-42", new TimeSpan(1, 20, 0), "Time is an illusion"), Is.True);
+            Assert.That(jiraClient.PostWorklog("DG-42", new TimeSpan(1, 20, 0), "Time is an illusion", EstimateUpdateMethods.Auto, null), Is.True);
         }
 
 
@@ -144,7 +144,7 @@
         public void PostWorklog_OnFailure_It_Returns_False()
         {
             jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<object>(It.IsAny<IRestRequest>())).Throws<RequestDeniedException>();
-            Assert.That(jiraClient.PostWorklog("DG-42", new TimeSpan(2, 10, 0), "Lunchtime doubly so"), Is.False);
+            Assert.That(jiraClient.PostWorklog("DG-42", new TimeSpan(2, 10, 0), "Lunchtime doubly so", EstimateUpdateMethods.Auto, null), Is.False);
         }
 
 

--- a/source/StopWatchTest/JiraClientTest.cs
+++ b/source/StopWatchTest/JiraClientTest.cs
@@ -130,6 +130,35 @@
             Assert.That(jiraClient.GetIssueSummary("DG-42"), Is.EqualTo(""));
         }
 
+        [Test, Description("GetIssueTimetracking: On success it returns a timetracking object")]
+        public void GetIssueTimetracking_OnSuccess_It_Returns_RemainingTime()
+        {
+            Issue returnData = new Issue
+            {
+                Fields = new IssueFields
+                {
+                    Summary = "The long dark tea-time of the soul",
+                    Timetracking = new TimetrackingFields
+                    {
+                        RemainingEstimate = "1h",
+                        RemainingEstimateSeconds = 360
+                    }
+                }
+            };
+
+            jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<Issue>(It.IsAny<IRestRequest>())).Returns(returnData);
+
+            Assert.That(jiraClient.GetIssueTimetracking("DG-42"), Is.EqualTo(returnData.Fields.Timetracking));
+        }
+
+
+        [Test, Description("GetIssueTimetracking: On failure it returns null")]
+        public void GetIssueTimetracking_OnFailure_It_Returns_Empty_String()
+        {
+            jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<Issue>(It.IsAny<IRestRequest>())).Throws<RequestDeniedException>();
+            Assert.That(jiraClient.GetIssueTimetracking("DG-42"), Is.Null);
+        }
+
 
         [Test, Description("PostWorklog: On success it returns true")]
         public void PostWorklog_OnSuccess_It_Returns_True()


### PR DESCRIPTION
Here is a fix for my feature request (#35):
* New option in settings (default true) controls whether or not to show the new fields
* If shown, then you the worklog form has radio buttons under the fields allowing you to specify what should happen to the remaining estimate.  Options are:
** Adjust Automatically (shows estimate of what it should adjust to, but the actual adjustment is left up to Jira)
** Leave Unchanged (shows current value)
** Set to (there is then a text field for you to specify to what)
** Reduce by (also has a text field allowing you to specify how much to reduce by)

These match the options shown when logging work in Jira itself.