### PR TITLE
Using current screen's working area instead of the main screen's.

### DIFF
--- a/source/StopWatch/UI/MainForm.cs
+++ b/source/StopWatch/UI/MainForm.cs
@@ -377,11 +377,12 @@ namespace StopWatch
 
             this.ClientSize = new Size(pBottom.Width, this.settings.IssueCount * issueControls.Last().Height + pMain.Top + pBottom.Height);
 
-            if (this.Height > Screen.PrimaryScreen.WorkingArea.Height)
-                this.Height = Screen.PrimaryScreen.WorkingArea.Height;
+            var workingArea = Screen.FromControl(this).WorkingArea;
+            if (this.Height > workingArea.Height)
+                this.Height = workingArea.Height;
 
-            if (this.Bottom > Screen.PrimaryScreen.WorkingArea.Height)
-                this.Top = Screen.PrimaryScreen.WorkingArea.Height - this.Height;
+            if (this.Bottom > workingArea.Bottom)
+                this.Top = workingArea.Bottom - this.Height;
             
             pMain.Height = ClientSize.Height - pTop.Height - pBottom.Height;
             pBottom.Top = ClientSize.Height - pBottom.Height;


### PR DESCRIPTION
Fixes an issue where the window was jumping higher in the screen even
though it was not even close to the bottom of the working area. This
happens when, for example, the main screen has landscape orientation and
the screen where you use the app has portrait orientation.

Also found that comparing to Bottom instead of Height gives more precise
results for some reason. Tested with landscape/portrait monitors, and with
taskbar on top and bottom of screen.