### PR TITLE
Accept zero without units as remaining time

### DIFF
--- a/source/StopWatch/Helpers/JiraTimeHelpers.cs
+++ b/source/StopWatch/Helpers/JiraTimeHelpers.cs
@@ -48,6 +48,9 @@ namespace StopWatch
 
             time = time.Trim();
 
+            if (time == "0")
+                return TimeSpan.Zero;
+
             MatchCollection matches = new Regex(@"([0-9,\.]+[dhm] *?)+?", RegexOptions.IgnoreCase).Matches(time);
             if (matches.Count == 0)
                 return null;

--- a/source/StopWatchTest/JiraTimeHelpersTest.cs
+++ b/source/StopWatchTest/JiraTimeHelpersTest.cs
@@ -84,6 +84,7 @@
             Assert.AreEqual(120, JiraTimeHelpers.JiraTimeToTimeSpan("2h").Value.TotalMinutes);
             Assert.AreEqual(125, JiraTimeHelpers.JiraTimeToTimeSpan("2h 5m").Value.TotalMinutes);
             Assert.AreEqual(5, JiraTimeHelpers.JiraTimeToTimeSpan("5m").Value.TotalMinutes);
+            Assert.AreEqual(0, JiraTimeHelpers.JiraTimeToTimeSpan("0").Value.TotalMinutes);
         }
 
         [Test]


### PR DESCRIPTION
Accept a time value of "0" without having to specify units when entering a remaining estimate (set to, or reduce by). JIRA has a default unit, which is another way of not having to specify units (future feature, maybe?).