### PR TITLE
Fix issue summary disappearing randomly

### DIFF
--- a/source/StopWatch/Jira/JiraClient.cs
+++ b/source/StopWatch/Jira/JiraClient.cs
@@ -103,14 +103,7 @@ namespace StopWatch
         public string GetIssueSummary(string key)
         {
             var request = jiraApiRequestFactory.CreateGetIssueSummaryRequest(key);
-            try
-            {
-                return jiraApiRequester.DoAuthenticatedRequest<Issue>(request).Fields.Summary;
-            }
-            catch (RequestDeniedException)
-            {
-                return "";
-            }
+            return jiraApiRequester.DoAuthenticatedRequest<Issue>(request).Fields.Summary;
         }
 
         public TimetrackingFields GetIssueTimetracking(string key)

--- a/source/StopWatch/UI/IssueControl.cs
+++ b/source/StopWatch/UI/IssueControl.cs
@@ -205,10 +205,17 @@ namespace StopWatch
                     this.InvokeIfRequired(
                         () => key = cbJira.Text
                     );
-                    summary = jiraClient.GetIssueSummary(key);
-                    this.InvokeIfRequired(
-                        () => lblSummary.Text = summary
-                    );
+                    try
+                    {
+                        summary = jiraClient.GetIssueSummary(key);
+                        this.InvokeIfRequired(
+                            () => lblSummary.Text = summary
+                        );
+                    }
+                    catch (RequestDeniedException)
+                    {
+                        // just leave the existing summary there when fetch fails
+                    }
                 }
             );
         }


### PR DESCRIPTION
When the call to GetIssueSummary failed, it erased the summary and left it empty. Happens frequently (many times a day) under some conditions. Required to press enter on the issue number again to force another try. With this fix, it just stays as is until the next refresh that succeeds.