### PR TITLE
Added an optional display of the issue's project name.

### DIFF
--- a/source/StopWatch/App.config
+++ b/source/StopWatch/App.config
@@ -78,6 +78,9 @@ limitations under the License.
             <setting name="CheckForUpdate" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="IncludeProjectName" serializeAs="String">
+                <value>False</value>
+            </setting>
         </StopWatch.Properties.Settings>
     </userSettings>
 </configuration>

--- a/source/StopWatch/Jira/DTO/IssueFields.cs
+++ b/source/StopWatch/Jira/DTO/IssueFields.cs
@@ -19,11 +19,17 @@ namespace StopWatch
     {
         public string Summary { get; set; }
         public TimetrackingFields Timetracking { get; set; }
+        public ProjectFields Project { get; set; }
     }
 
     internal class TimetrackingFields
     {
         public string RemainingEstimate { get; set; }
         public int RemainingEstimateSeconds { get; set; }
+    }
+
+    internal class ProjectFields
+    {
+        public string Name { get; set; } 
     }
 }

--- a/source/StopWatch/Jira/JiraClient.cs
+++ b/source/StopWatch/Jira/JiraClient.cs
@@ -100,10 +100,11 @@ namespace StopWatch
         }
 
 
-        public string GetIssueSummary(string key)
+        public string GetIssueSummary(string key, bool addProjectName)
         {
             var request = jiraApiRequestFactory.CreateGetIssueSummaryRequest(key);
-            return jiraApiRequester.DoAuthenticatedRequest<Issue>(request).Fields.Summary;
+            var issue = jiraApiRequester.DoAuthenticatedRequest<Issue>(request).Fields;
+            return addProjectName ? issue.Project.Name + ": " + issue.Summary : issue.Summary;
         }
 
         public TimetrackingFields GetIssueTimetracking(string key)

--- a/source/StopWatch/Properties/Settings.Designer.cs
+++ b/source/StopWatch/Properties/Settings.Designer.cs
@@ -226,5 +226,17 @@ namespace StopWatch.Properties {
                 this["CheckForUpdate"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool IncludeProjectName {
+            get {
+                return ((bool)(this["IncludeProjectName"]));
+            }
+            set {
+                this["IncludeProjectName"] = value;
+            }
+        }
     }
 }

--- a/source/StopWatch/Properties/Settings.settings
+++ b/source/StopWatch/Properties/Settings.settings
@@ -53,5 +53,8 @@
     <Setting Name="CheckForUpdate" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="IncludeProjectName" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/source/StopWatch/Settings/Settings.cs
+++ b/source/StopWatch/Settings/Settings.cs
@@ -52,6 +52,7 @@ namespace StopWatch
         public bool MinimizeToTray { get; set; }
         public int IssueCount { get; set; }
         public bool AllowMultipleTimers { get; set; }
+        public bool IncludeProjectName { get; set; }
 
         public SaveTimerSetting SaveTimerState { get; set; }
         public PauseAndResumeSetting PauseOnSessionLock { get; set; }
@@ -114,6 +115,7 @@ namespace StopWatch
             this.JiraBaseUrl = Properties.Settings.Default.JiraBaseUrl ?? "";
 
             this.AlwaysOnTop = Properties.Settings.Default.AlwaysOnTop;
+            this.IncludeProjectName = Properties.Settings.Default.IncludeProjectName;
             this.MinimizeToTray = Properties.Settings.Default.MinimizeToTray;
             this.IssueCount = Properties.Settings.Default.IssueCount;
             this.Username = Properties.Settings.Default.Username;
@@ -149,6 +151,7 @@ namespace StopWatch
                 Properties.Settings.Default.AlwaysOnTop = this.AlwaysOnTop;
                 Properties.Settings.Default.MinimizeToTray = this.MinimizeToTray;
                 Properties.Settings.Default.IssueCount = this.IssueCount;
+                Properties.Settings.Default.IncludeProjectName = this.IncludeProjectName;
 
                 Properties.Settings.Default.Username = this.Username;
                 if (this.Password != "")

--- a/source/StopWatch/UI/IssueControl.cs
+++ b/source/StopWatch/UI/IssueControl.cs
@@ -207,7 +207,7 @@ namespace StopWatch
                     );
                     try
                     {
-                        summary = jiraClient.GetIssueSummary(key);
+                        summary = jiraClient.GetIssueSummary(key, settings.IncludeProjectName);
                         this.InvokeIfRequired(
                             () => lblSummary.Text = summary
                         );

--- a/source/StopWatch/UI/SettingsForm.Designer.cs
+++ b/source/StopWatch/UI/SettingsForm.Designer.cs
@@ -71,6 +71,7 @@ namespace StopWatch
             this.lblPassword = new System.Windows.Forms.Label();
             this.tbUsername = new System.Windows.Forms.TextBox();
             this.lblUsername = new System.Windows.Forms.Label();
+            this.cbIncludeProjectName = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // lblJiraBaseUrl
@@ -106,7 +107,7 @@ namespace StopWatch
             // 
             this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOk.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnOk.Location = new System.Drawing.Point(263, 443);
+            this.btnOk.Location = new System.Drawing.Point(263, 464);
             this.btnOk.Margin = new System.Windows.Forms.Padding(2);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(56, 22);
@@ -117,7 +118,7 @@ namespace StopWatch
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(324, 443);
+            this.btnCancel.Location = new System.Drawing.Point(324, 464);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(2);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(56, 22);
@@ -127,7 +128,7 @@ namespace StopWatch
             // 
             // lblSaveTimerState
             // 
-            this.lblSaveTimerState.Location = new System.Drawing.Point(9, 206);
+            this.lblSaveTimerState.Location = new System.Drawing.Point(9, 227);
             this.lblSaveTimerState.Name = "lblSaveTimerState";
             this.lblSaveTimerState.Size = new System.Drawing.Size(98, 38);
             this.lblSaveTimerState.TabIndex = 14;
@@ -135,7 +136,7 @@ namespace StopWatch
             // 
             // btnAbout
             // 
-            this.btnAbout.Location = new System.Drawing.Point(11, 443);
+            this.btnAbout.Location = new System.Drawing.Point(11, 464);
             this.btnAbout.Margin = new System.Windows.Forms.Padding(2);
             this.btnAbout.Name = "btnAbout";
             this.btnAbout.Size = new System.Drawing.Size(56, 22);
@@ -159,14 +160,14 @@ namespace StopWatch
             // 
             this.cbSaveTimerState.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbSaveTimerState.FormattingEnabled = true;
-            this.cbSaveTimerState.Location = new System.Drawing.Point(122, 208);
+            this.cbSaveTimerState.Location = new System.Drawing.Point(122, 229);
             this.cbSaveTimerState.Name = "cbSaveTimerState";
             this.cbSaveTimerState.Size = new System.Drawing.Size(258, 21);
             this.cbSaveTimerState.TabIndex = 15;
             // 
             // lblPauseOnSessionLock
             // 
-            this.lblPauseOnSessionLock.Location = new System.Drawing.Point(9, 244);
+            this.lblPauseOnSessionLock.Location = new System.Drawing.Point(9, 265);
             this.lblPauseOnSessionLock.Name = "lblPauseOnSessionLock";
             this.lblPauseOnSessionLock.Size = new System.Drawing.Size(98, 38);
             this.lblPauseOnSessionLock.TabIndex = 16;
@@ -176,7 +177,7 @@ namespace StopWatch
             // 
             this.cbPauseOnSessionLock.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbPauseOnSessionLock.FormattingEnabled = true;
-            this.cbPauseOnSessionLock.Location = new System.Drawing.Point(122, 246);
+            this.cbPauseOnSessionLock.Location = new System.Drawing.Point(122, 267);
             this.cbPauseOnSessionLock.Name = "cbPauseOnSessionLock";
             this.cbPauseOnSessionLock.Size = new System.Drawing.Size(176, 21);
             this.cbPauseOnSessionLock.TabIndex = 17;
@@ -184,7 +185,7 @@ namespace StopWatch
             // splitter3
             // 
             this.splitter3.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.splitter3.Location = new System.Drawing.Point(12, 432);
+            this.splitter3.Location = new System.Drawing.Point(12, 453);
             this.splitter3.Name = "splitter3";
             this.splitter3.Size = new System.Drawing.Size(370, 2);
             this.splitter3.TabIndex = 25;
@@ -192,7 +193,7 @@ namespace StopWatch
             // splitter2
             // 
             this.splitter2.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.splitter2.Location = new System.Drawing.Point(12, 194);
+            this.splitter2.Location = new System.Drawing.Point(12, 215);
             this.splitter2.Name = "splitter2";
             this.splitter2.Size = new System.Drawing.Size(370, 2);
             this.splitter2.TabIndex = 13;
@@ -208,7 +209,7 @@ namespace StopWatch
             // cbAllowMultipleTimers
             // 
             this.cbAllowMultipleTimers.AutoSize = true;
-            this.cbAllowMultipleTimers.Location = new System.Drawing.Point(122, 284);
+            this.cbAllowMultipleTimers.Location = new System.Drawing.Point(122, 305);
             this.cbAllowMultipleTimers.Margin = new System.Windows.Forms.Padding(2);
             this.cbAllowMultipleTimers.Name = "cbAllowMultipleTimers";
             this.cbAllowMultipleTimers.Size = new System.Drawing.Size(228, 17);
@@ -220,14 +221,14 @@ namespace StopWatch
             // 
             this.cbPostWorklogComment.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbPostWorklogComment.FormattingEnabled = true;
-            this.cbPostWorklogComment.Location = new System.Drawing.Point(122, 313);
+            this.cbPostWorklogComment.Location = new System.Drawing.Point(122, 334);
             this.cbPostWorklogComment.Name = "cbPostWorklogComment";
             this.cbPostWorklogComment.Size = new System.Drawing.Size(198, 21);
             this.cbPostWorklogComment.TabIndex = 20;
             // 
             // lblPostWorklogComment
             // 
-            this.lblPostWorklogComment.Location = new System.Drawing.Point(9, 311);
+            this.lblPostWorklogComment.Location = new System.Drawing.Point(9, 332);
             this.lblPostWorklogComment.Name = "lblPostWorklogComment";
             this.lblPostWorklogComment.Size = new System.Drawing.Size(98, 38);
             this.lblPostWorklogComment.TabIndex = 19;
@@ -245,14 +246,14 @@ namespace StopWatch
             // label1
             // 
             this.label1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.label1.Location = new System.Drawing.Point(11, 351);
+            this.label1.Location = new System.Drawing.Point(11, 372);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(370, 2);
             this.label1.TabIndex = 22;
             // 
             // lblStartTransitions
             // 
-            this.lblStartTransitions.Location = new System.Drawing.Point(9, 365);
+            this.lblStartTransitions.Location = new System.Drawing.Point(9, 386);
             this.lblStartTransitions.Name = "lblStartTransitions";
             this.lblStartTransitions.Size = new System.Drawing.Size(107, 52);
             this.lblStartTransitions.TabIndex = 23;
@@ -261,7 +262,7 @@ namespace StopWatch
             // tbStartTransitions
             // 
             this.tbStartTransitions.AcceptsReturn = true;
-            this.tbStartTransitions.Location = new System.Drawing.Point(122, 365);
+            this.tbStartTransitions.Location = new System.Drawing.Point(122, 386);
             this.tbStartTransitions.Multiline = true;
             this.tbStartTransitions.Name = "tbStartTransitions";
             this.tbStartTransitions.Size = new System.Drawing.Size(200, 52);
@@ -337,13 +338,25 @@ namespace StopWatch
             this.lblUsername.TabIndex = 2;
             this.lblUsername.Text = "Username";
             // 
+            // cbIncludeProjectName
+            // 
+            this.cbIncludeProjectName.AutoSize = true;
+            this.cbIncludeProjectName.Location = new System.Drawing.Point(122, 188);
+            this.cbIncludeProjectName.Margin = new System.Windows.Forms.Padding(2);
+            this.cbIncludeProjectName.Name = "cbIncludeProjectName";
+            this.cbIncludeProjectName.Size = new System.Drawing.Size(207, 17);
+            this.cbIncludeProjectName.TabIndex = 13;
+            this.cbIncludeProjectName.Text = "Include project name in issue summary";
+            this.cbIncludeProjectName.UseVisualStyleBackColor = true;
+            // 
             // SettingsForm
             // 
             this.AcceptButton = this.btnOk;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(397, 475);
+            this.ClientSize = new System.Drawing.Size(391, 494);
+            this.Controls.Add(this.cbIncludeProjectName);
             this.Controls.Add(this.tbPassword);
             this.Controls.Add(this.lblPassword);
             this.Controls.Add(this.tbUsername);
@@ -413,5 +426,6 @@ namespace StopWatch
         private System.Windows.Forms.Label lblPassword;
         private System.Windows.Forms.TextBox tbUsername;
         private System.Windows.Forms.Label lblUsername;
+        private System.Windows.Forms.CheckBox cbIncludeProjectName;
     }
 }

--- a/source/StopWatch/UI/SettingsForm.cs
+++ b/source/StopWatch/UI/SettingsForm.cs
@@ -47,6 +47,7 @@ namespace StopWatch
             cbAlwaysOnTop.Checked = this.settings.AlwaysOnTop;
             cbMinimizeToTray.Checked = this.settings.MinimizeToTray;
             cbAllowMultipleTimers.Checked = this.settings.AllowMultipleTimers;
+            cbIncludeProjectName.Checked = this.settings.IncludeProjectName;
 
             cbSaveTimerState.DisplayMember = "Text";
             cbSaveTimerState.ValueMember = "Value";
@@ -99,6 +100,7 @@ namespace StopWatch
                 this.settings.AlwaysOnTop = cbAlwaysOnTop.Checked;
                 this.settings.MinimizeToTray = cbMinimizeToTray.Checked;
                 this.settings.AllowMultipleTimers = cbAllowMultipleTimers.Checked;
+                this.settings.IncludeProjectName = cbIncludeProjectName.Checked;
 
                 this.settings.SaveTimerState = (SaveTimerSetting)cbSaveTimerState.SelectedValue;
                 this.settings.PauseOnSessionLock = (PauseAndResumeSetting)cbPauseOnSessionLock.SelectedValue;

--- a/source/StopWatchTest/JiraClientTest.cs
+++ b/source/StopWatchTest/JiraClientTest.cs
@@ -119,7 +119,7 @@
 
             jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<Issue>(It.IsAny<IRestRequest>())).Returns(returnData);
 
-            Assert.That(jiraClient.GetIssueSummary("DG-42"), Is.EqualTo(returnData.Fields.Summary));
+            Assert.That(jiraClient.GetIssueSummary("DG-42",false), Is.EqualTo(returnData.Fields.Summary));
         }
 
 
@@ -127,7 +127,7 @@
         public void GetIssueSummary_OnFailure_It_Returns_Empty_String()
         {
             jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<Issue>(It.IsAny<IRestRequest>())).Throws<RequestDeniedException>();
-            Assert.That(jiraClient.GetIssueSummary("DG-42"), Is.EqualTo(""));
+            Assert.That(jiraClient.GetIssueSummary("DG-42",false), Is.EqualTo(""));
         }
 
         [Test, Description("GetIssueTimetracking: On success it returns a timetracking object")]


### PR DESCRIPTION
This adds an optional display of the project name in the issue row. We have over 50 projects in our JIRA and a lot of them are "templated", where issue 1 is always a project summary and so on.

By itself, the project ID in the issue ID is not always informative.

This adds the option to the settings dialog (disabled by default to replicate current behavior). When the option is enabled the issue name is prefixed with the project name and ": ".