### PR TITLE
Actual start time

### DIFF
--- a/source/StopWatch/Jira/JiraClient.cs
+++ b/source/StopWatch/Jira/JiraClient.cs
@@ -121,10 +121,9 @@ namespace StopWatch
         }
 
 
-        public bool PostWorklog(string key, TimeSpan time, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
+        public bool PostWorklog(string key, DateTimeOffset startTime, TimeSpan time, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {
-            var started = DateTimeOffset.UtcNow.Subtract(time);
-            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, started, time, comment, estimateUpdateMethod, estimateUpdateValue);
+            var request = jiraApiRequestFactory.CreatePostWorklogRequest(key, startTime, time, comment, estimateUpdateMethod, estimateUpdateValue);
             try
             {
                 jiraApiRequester.DoAuthenticatedRequest<object>(request);

--- a/source/StopWatch/Settings/PersistedIssue.cs
+++ b/source/StopWatch/Settings/PersistedIssue.cs
@@ -22,7 +22,8 @@ namespace StopWatch
     {
         public string Key { get; set; }
         public bool TimerRunning { get; set; }
-        public DateTime StartTime { get; set; }
+        public DateTimeOffset? InitialStartTime { get; set; }
+        public DateTime SessionStartTime { get; set; }
         public TimeSpan TotalTime { get; set; }
         public string Comment { get; set; }
         public EstimateUpdateMethods EstimateUpdateMethod { get; set; }

--- a/source/StopWatch/UI/IssueControl.cs
+++ b/source/StopWatch/UI/IssueControl.cs
@@ -576,7 +576,7 @@ namespace StopWatch
 
         public void PostAndReset()
         {
-            using (var worklogForm = new WorklogForm(WatchTimer.TimeElapsed, Comment, EstimateUpdateMethod, EstimateUpdateValue))
+            using (var worklogForm = new WorklogForm(WatchTimer.GetInitialStartTime(), WatchTimer.TimeElapsed, Comment, EstimateUpdateMethod, EstimateUpdateValue))
             {
                 UpdateRemainingEstimate(worklogForm);
                 var formResult = worklogForm.ShowDialog(this);
@@ -586,7 +586,7 @@ namespace StopWatch
                     EstimateUpdateMethod = worklogForm.estimateUpdateMethod;
                     EstimateUpdateValue = worklogForm.EstimateValue;
 
-                    PostAndReset(cbJira.Text, WatchTimer.GetInitialStartTime(), WatchTimer.TimeElapsed, Comment, EstimateUpdateMethod, EstimateUpdateValue);
+                    PostAndReset(cbJira.Text, worklogForm.InitialStartTime, WatchTimer.TimeElapsed, Comment, EstimateUpdateMethod, EstimateUpdateValue);
                 }
                 else if (formResult == DialogResult.Yes)
                 {

--- a/source/StopWatch/UI/IssueControl.cs
+++ b/source/StopWatch/UI/IssueControl.cs
@@ -586,7 +586,7 @@ namespace StopWatch
                     EstimateUpdateMethod = worklogForm.estimateUpdateMethod;
                     EstimateUpdateValue = worklogForm.EstimateValue;
 
-                    PostAndReset(cbJira.Text, WatchTimer.TimeElapsed, Comment, EstimateUpdateMethod, EstimateUpdateValue);
+                    PostAndReset(cbJira.Text, WatchTimer.GetInitialStartTime(), WatchTimer.TimeElapsed, Comment, EstimateUpdateMethod, EstimateUpdateValue);
                 }
                 else if (formResult == DialogResult.Yes)
                 {
@@ -620,7 +620,7 @@ namespace StopWatch
 
 
         #region private methods
-        private void PostAndReset(string key, TimeSpan timeElapsed, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
+        private void PostAndReset(string key, DateTimeOffset startTime, TimeSpan timeElapsed, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {
             Task.Factory.StartNew(
                 () =>
@@ -645,7 +645,7 @@ namespace StopWatch
 
                     // Now post the WorkLog with timeElapsed - and comment unless it was reset
                     if (postSuccesful)
-                        postSuccesful = jiraClient.PostWorklog(key, timeElapsed, comment, estimateUpdateMethod, estimateUpdateValue);
+                        postSuccesful = jiraClient.PostWorklog(key, startTime, timeElapsed, comment, estimateUpdateMethod, estimateUpdateValue);
 
                     if (postSuccesful)
                     {

--- a/source/StopWatch/UI/MainForm.cs
+++ b/source/StopWatch/UI/MainForm.cs
@@ -185,7 +185,8 @@ namespace StopWatch
                         TimerState timerState = new TimerState
                         {
                             Running = this.settings.SaveTimerState == SaveTimerSetting.SavePause ? false : persistedIssue.TimerRunning,
-                            StartTime = persistedIssue.StartTime,
+                            SessionStartTime = persistedIssue.SessionStartTime,
+                            InitialStartTime = persistedIssue.InitialStartTime,
                             TotalTime = persistedIssue.TotalTime
                         };
                         issueControl.WatchTimer.SetState(timerState);
@@ -554,7 +555,8 @@ namespace StopWatch
                 {
                     Key = issueControl.IssueKey,
                     TimerRunning = timerState.Running,
-                    StartTime = timerState.StartTime,
+                    SessionStartTime = timerState.SessionStartTime,
+                    InitialStartTime = timerState.InitialStartTime,
                     TotalTime = timerState.TotalTime,
                     Comment = issueControl.Comment,
                     EstimateUpdateMethod = issueControl.EstimateUpdateMethod,

--- a/source/StopWatch/UI/WorklogForm.Designer.cs
+++ b/source/StopWatch/UI/WorklogForm.Designer.cs
@@ -57,6 +57,9 @@ namespace StopWatch
             this.rdEstimateAdjustManualDecrease = new System.Windows.Forms.RadioButton();
             this.rdEstimateAdjustSetTo = new System.Windows.Forms.RadioButton();
             this.rdEstimateAdjustLeave = new System.Windows.Forms.RadioButton();
+            this.startDatePicker = new System.Windows.Forms.DateTimePicker();
+            this.label1 = new System.Windows.Forms.Label();
+            this.startTimePicker = new System.Windows.Forms.DateTimePicker();
             this.gbRemainingEstimate.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -84,7 +87,7 @@ namespace StopWatch
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(254, 302);
+            this.btnCancel.Location = new System.Drawing.Point(254, 336);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(2);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(56, 23);
@@ -96,7 +99,7 @@ namespace StopWatch
             // 
             this.btnOk.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnOk.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.btnOk.Location = new System.Drawing.Point(193, 302);
+            this.btnOk.Location = new System.Drawing.Point(193, 336);
             this.btnOk.Margin = new System.Windows.Forms.Padding(2);
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(56, 23);
@@ -108,7 +111,7 @@ namespace StopWatch
             // lblInfo
             // 
             this.lblInfo.AutoSize = true;
-            this.lblInfo.Location = new System.Drawing.Point(11, 282);
+            this.lblInfo.Location = new System.Drawing.Point(11, 316);
             this.lblInfo.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblInfo.Name = "lblInfo";
             this.lblInfo.Size = new System.Drawing.Size(137, 13);
@@ -118,7 +121,7 @@ namespace StopWatch
             // btnSave
             // 
             this.btnSave.DialogResult = System.Windows.Forms.DialogResult.Yes;
-            this.btnSave.Location = new System.Drawing.Point(11, 302);
+            this.btnSave.Location = new System.Drawing.Point(11, 336);
             this.btnSave.Margin = new System.Windows.Forms.Padding(2);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(83, 23);
@@ -148,7 +151,7 @@ namespace StopWatch
             this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustSetTo);
             this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustLeave);
             this.gbRemainingEstimate.Controls.Add(this.rdEstimateAdjustAuto);
-            this.gbRemainingEstimate.Location = new System.Drawing.Point(14, 174);
+            this.gbRemainingEstimate.Location = new System.Drawing.Point(14, 208);
             this.gbRemainingEstimate.Name = "gbRemainingEstimate";
             this.gbRemainingEstimate.Size = new System.Drawing.Size(299, 102);
             this.gbRemainingEstimate.TabIndex = 2;
@@ -213,13 +216,47 @@ namespace StopWatch
             this.rdEstimateAdjustLeave.CheckedChanged += new System.EventHandler(this.estimateUpdateMethod_changed);
             this.rdEstimateAdjustLeave.KeyDown += new System.Windows.Forms.KeyEventHandler(this.rdEstimateAdjustLeave_KeyDown);
             // 
+            // startDatePicker
+            // 
+            this.startDatePicker.AccessibleDescription = "Start Date";
+            this.startDatePicker.AccessibleName = "StartDate";
+            this.startDatePicker.Location = new System.Drawing.Point(124, 176);
+            this.startDatePicker.Name = "startDatePicker";
+            this.startDatePicker.ShowUpDown = true;
+            this.startDatePicker.Size = new System.Drawing.Size(115, 20);
+            this.startDatePicker.TabIndex = 11;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(19, 182);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(55, 13);
+            this.label1.TabIndex = 12;
+            this.label1.Text = "Start Time";
+            // 
+            // startTimePicker
+            // 
+            this.startTimePicker.AccessibleDescription = "Start Time";
+            this.startTimePicker.AccessibleName = "StartTime";
+            this.startTimePicker.CustomFormat = "HH:mm";
+            this.startTimePicker.Format = System.Windows.Forms.DateTimePickerFormat.Custom;
+            this.startTimePicker.Location = new System.Drawing.Point(254, 176);
+            this.startTimePicker.Name = "startTimePicker";
+            this.startTimePicker.ShowUpDown = true;
+            this.startTimePicker.Size = new System.Drawing.Size(59, 20);
+            this.startTimePicker.TabIndex = 13;
+            // 
             // WorklogForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(321, 332);
+            this.ClientSize = new System.Drawing.Size(321, 367);
+            this.Controls.Add(this.startTimePicker);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.startDatePicker);
             this.Controls.Add(this.gbRemainingEstimate);
             this.Controls.Add(this.btnSave);
             this.Controls.Add(this.lblInfo);
@@ -254,5 +291,8 @@ namespace StopWatch
         private TextBox tbSetTo;
         private TextBox tbReduceBy;
         public RadioButton rdEstimateAdjustLeave;
+        private DateTimePicker startDatePicker;
+        private Label label1;
+        private DateTimePicker startTimePicker;
     }
 }

--- a/source/StopWatch/UI/WorklogForm.cs
+++ b/source/StopWatch/UI/WorklogForm.cs
@@ -53,7 +53,13 @@ namespace StopWatch
                 }
             }
         }
-
+        public DateTimeOffset InitialStartTime
+        {
+            get
+            {
+                return this.startDatePicker.Value.Date + this.startTimePicker.Value.TimeOfDay;
+            }
+        }
         public string RemainingEstimate
         {
             get
@@ -83,9 +89,17 @@ namespace StopWatch
 
 
         #region public methods
-        public WorklogForm(TimeSpan TimeElapsed, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
+        public WorklogForm(DateTimeOffset startTime, TimeSpan TimeElapsed, string comment, EstimateUpdateMethods estimateUpdateMethod, string estimateUpdateValue)
         {            
             this.TimeElapsed = TimeElapsed;
+            DateTimeOffset initialStartTime;
+            if (startTime == null)
+            {
+                initialStartTime = DateTimeOffset.UtcNow.Subtract(TimeElapsed);
+            }else
+            {
+                initialStartTime = startTime;
+            }
             InitializeComponent();
             if (!String.IsNullOrEmpty(comment))
             {
@@ -93,7 +107,13 @@ namespace StopWatch
                 tbComment.SelectionStart = 0;
             }
 
-            switch( estimateUpdateMethod ) {
+            // I don't see why I need to do this, but the first time I call LocalDateTime it seems to change time zone on the actual Date4TimeOffset
+            // So I don't get the right time.  So I call just once and update both from the same object
+            DateTime localInitialStartTime = initialStartTime.LocalDateTime;
+            this.startDatePicker.Value = localInitialStartTime;
+            this.startTimePicker.Value = localInitialStartTime;
+
+            switch ( estimateUpdateMethod ) {
                 case EstimateUpdateMethods.Auto:
                     rdEstimateAdjustAuto.Checked = true;
                     break;

--- a/source/StopWatchTest/JiraClientTest.cs
+++ b/source/StopWatchTest/JiraClientTest.cs
@@ -165,7 +165,7 @@
         {
             jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<object>(It.IsAny<IRestRequest>())).Returns(new object());
 
-            Assert.That(jiraClient.PostWorklog("DG-42", new TimeSpan(1, 20, 0), "Time is an illusion", EstimateUpdateMethods.Auto, null), Is.True);
+            Assert.That(jiraClient.PostWorklog("DG-42", DateTimeOffset.UtcNow, new TimeSpan(1, 20, 0), "Time is an illusion", EstimateUpdateMethods.Auto, null), Is.True);
         }
 
 
@@ -173,7 +173,7 @@
         public void PostWorklog_OnFailure_It_Returns_False()
         {
             jiraApiRequesterMock.Setup(m => m.DoAuthenticatedRequest<object>(It.IsAny<IRestRequest>())).Throws<RequestDeniedException>();
-            Assert.That(jiraClient.PostWorklog("DG-42", new TimeSpan(2, 10, 0), "Lunchtime doubly so", EstimateUpdateMethods.Auto, null), Is.False);
+            Assert.That(jiraClient.PostWorklog("DG-42", DateTimeOffset.UtcNow, new TimeSpan(2, 10, 0), "Lunchtime doubly so", EstimateUpdateMethods.Auto, null), Is.False);
         }
 
 


### PR DESCRIPTION
Log using actual start time

Added logic to record actual start time (first press of play for that row since last log/reset) and use that when logging.  Also added start time to the log dialogue so you can see it and adjust if wanted.

Fixes #66 



