### PR TITLE
Update MainForm.cs

### DIFF
--- a/source/StopWatch/UI/MainForm.cs
+++ b/source/StopWatch/UI/MainForm.cs
@@ -721,7 +721,7 @@ namespace StopWatch
         #region private consts
         private const int firstDelay = 500;
         private const int defaultDelay = 30000;
-        private const int maxIssues = 20;
+        private const int maxIssues = 60;
         #endregion
 
         private int currentIssueIndex;


### PR DESCRIPTION
Increased maximum number of timers in the list from 20 to 60. This was requested in issue #158
A very simple change to a constant. I have been testing it for 2 months and found no problem.
Please just pull it and make a new setup.